### PR TITLE
Always use default ghaf repo for polling

### DIFF
--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -38,9 +38,7 @@ pipeline {
     stage('Configure target repo') {
       steps {
         script {
-          SCM = git(url: REPO, branch: 'main')
-          echo 'Print target SCM'
-          echo SCM.toString()
+          SCM = git(url: DEF_GHAF_REPO, branch: DEF_GITREF)
         }
       }
     }


### PR DESCRIPTION
Always use the `DEF_GHAF_REPO` and `DEF_GITREF` when polling changes from the ghaf repo.
Before this change, the pipeline would poll the repo that was last given as a parameter to the build job.
Instead, we want to always poll the `DEF_GHAF_REPO` instead of the latest manual build target repo.