### PR TITLE
Add aarch64 build targets

### DIFF
--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -77,6 +77,16 @@ pipeline {
             }
           }
         }
+        stage('Build on aarch64') {
+          steps {
+            dir('ghaf') {
+              sh 'nix build -L .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug -o result-aarch64-jetson-orin-agx-debug'
+              sh 'nix build -L .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug  -o result-aarch64-jetson-orin-nx-debug'
+              sh 'nix build -L .#packages.aarch64-linux.imx8qm-mek-debug             -o result-aarch64-imx8qm-mek-debug'
+              sh 'nix build -L .#packages.aarch64-linux.doc                          -o result-aarch64-doc'
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
After https://github.com/tiiuae/ghaf-infra/pull/81, azure images based ghaf-infra can build native aarch64 targets.
This change adds relevant Ghaf aarch64 targets to the Jenkins pipeline.

Notice: when this change is merged, ghaf-infra instances need to be updated (re-deployed) to include the change from  https://github.com/tiiuae/ghaf-infra/pull/81. This re-deployment has already been done for the 'dev' instance, but notifying this here, since it might impact 'priv' ghaf-infra instances.