### PR TITLE
Store build results and discard old build records

### DIFF
--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -26,7 +26,15 @@ properties([
 
 pipeline {
   agent { label 'built-in' }
-  options { timestamps () }
+  options {
+    timestamps ()
+    buildDiscarder logRotator(
+      artifactDaysToKeepStr: '7',
+      artifactNumToKeepStr: '10',
+      daysToKeepStr: '70',
+      numToKeepStr: '100'
+    )
+  }
   environment {
     // https://stackoverflow.com/questions/46680573
     REPO = params.getOrDefault('REPO', DEF_GHAF_REPO)
@@ -78,6 +86,11 @@ pipeline {
           }
         }
       }
+    }
+  }
+  post {
+    always {
+      archiveArtifacts allowEmptyArchive: true, artifacts: 'ghaf/result-*/**'
     }
   }
 }


### PR DESCRIPTION
Archives the build results as post step of pipeline.
Discard old builds and artifacts:
- build age: no older than 70 days
- build count: maximum 100 builds
- artifact age: no older than 7 days
- artifact count: maximum 10 builds
