### PR TITLE
Add provenance generation to pipeline

### DIFF
--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -37,6 +37,9 @@ pipeline {
     }
     stage('Build on x86_64') {
       steps {
+        script {
+          env.ts_build_begin = sh(script: 'date +%s', returnStdout: true).trim()
+        }
         dir('ghaf') {
           sh 'nix build -L .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 -o result-jetson-orin-agx-debug'
           sh 'nix build -L .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  -o result-jetson-orin-nx-debug'
@@ -54,6 +57,47 @@ pipeline {
           sh 'nix build -L .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug  -o result-aarch64-jetson-orin-nx-debug'
           sh 'nix build -L .#packages.aarch64-linux.imx8qm-mek-debug             -o result-aarch64-imx8qm-mek-debug'
           sh 'nix build -L .#packages.aarch64-linux.doc                          -o result-aarch64-doc'
+        }
+        script {
+          env.ts_build_finished = sh(script: 'date +%s', returnStdout: true).trim()
+        }
+      }
+    }
+    stage('Provenance') {
+      environment {
+        // TODO: Write our own buildtype and builder id documents
+        PROVENANCE_BUILD_TYPE = "https://docs.cimon.build/provenance/buildtypes/jenkins/v1"
+        PROVENANCE_BUILDER_ID = "https://github.com/tiiuae/ghaf-infra/tree/main/terraform"
+        PROVENANCE_INVOCATION_ID = "${env.JOB_NAME}/${env.BUILD_ID}"
+        PROVENANCE_TIMESTAMP_BEGIN = "${env.ts_build_begin}"
+        PROVENANCE_TIMESTAMP_FINISHED = "${env.ts_build_finished}"
+        PROVENANCE_EXTERNAL_PARAMS = sh(
+          returnStdout: true,
+          script: 'jq -n --arg flakeURI $URL --arg flakeBranch $BRANCH \'$ARGS.named\'' 
+        )
+        PROVENANCE_INTERNAL_PARAMS = sh(
+          returnStdout: true,
+          // returns the specified environment varibles in json format
+          script: """
+            jq -n env | jq "{ \
+              JOB_NAME, \
+              GIT_URL, \
+              GIT_BRANCH, \
+              GIT_COMMIT, \
+            }"
+          """
+        )
+      }
+      steps {
+        dir('ghaf') {
+          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --recursive --out result-provenance-jetson-orin-agx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  --recursive --out result-provenance-jetson-orin-nx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.generic-x86_64-debug                     --recursive --out result-provenance-generic-x86_64-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug             --recursive --out result-provenance-lenovo-x1-carbon-gen11-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.riscv64-linux.microchip-icicle-kit-debug              --recursive --out result-provenance-microchip-icicle-kit-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug            --recursive --out result-provenance-aarch64-jetson-orin-agx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug             --recursive --out result-provenance-aarch64-jetson-orin-nx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.imx8qm-mek-debug                        --recursive --out result-provenance-aarch64-imx8qm-mek-debug.json'
         }
       }
     }


### PR DESCRIPTION
Adds provenance generation step to the pipeline.

Build timestamps are created flanking the build steps. This is not ideal, as having different timestamps for each target would be more accurate, but our batched steps pipeline architecture does not allow for that.

As for the internal parameters, I tried to choose the most relevant ones from the environment variables that jenkins offers. Pasting the whole env there would be very messy.

Proper build type and builder id need to be decided in the future.

sample provenance file generated by pipeline: https://basedbin.fly.dev/p/TpMk29.json