### PR TITLE
Define builds and targets once. Simplify vulnxscan usage

### DIFF
--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -4,6 +4,50 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+
+def builds_x86_64=
+//  NAME OF THE BUILD TARGET ,                             NAME OF THE BUILD OUTPUT,                    SBOM TARGET BASE NAME,                              NAME OF THE PROVENANCE OUTPUT
+["x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64", "result-crosscompile-jetson-orin-agx-debug",  "result-sbom-crosscompile-jetson-orin-agx-debug",   "result-provenance-jetson-orin-agx-debug",
+"x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64",   "result-crosscompile-jetson-orin-nx-debug",   "result-sbom-crosscompile-jetson-orin-nx-debug",    "result-provenance-jetson-orin-nx-debug",
+"x86_64-linux.generic-x86_64-debug",                      "result-generic-x86_64-debug",                "result-generic-x86_64-debug",                      "result-provenance-generic-x86_64-debug",
+"x86_64-linux.lenovo-x1-carbon-gen11-debug",              "result-lenovo-x1-carbon-gen11-debug",        "result-lenovo-x1-carbon-gen11-debug",              "result-provenance-lenovo-x1-carbon-gen11-debug",
+"riscv64-linux.microchip-icicle-kit-debug",               "result-microchip-icicle-kit-debug",          "result-microchip-icicle-kit-debug",                "result-provenance-microchip-icicle-kit-debug",
+"x86_64-linux.doc",                                       "result-doc",                                 "NA",                                               "NA"]
+
+def builds_aarch_64=
+//  NAME OF THE BUILD TARGET ,                             NAME OF THE BUILD OUTPUT                     SBOM TARGET BASE NAME,                              NAME OF THE PROVENANCE OUTPUT
+["aarch64-linux.nvidia-jetson-orin-agx-debug",             "result-aarch64-jetson-orin-agx-debug",      "result-aarch64-jetson-orin-agx-debug",             "result-provenance-aarch64-jetson-orin-agx-debug",
+"aarch64-linux.nvidia-jetson-orin-nx-debug",               "result-aarch64-jetson-orin-nx-debug",       "result-aarch64-jetson-orin-nx-debug",              "result-provenance-aarch64-jetson-orin-nx-debug",
+"aarch64-linux.imx8qm-mek-debug",                          "result-aarch64-imx8qm-mek-debug",           "result-aarch64-imx8qm-mek-debug",                  "result-provenance-aarch64-imx8qm-mek-debug",
+"aarch64-linux.doc",                                       "result-aarch64-doc",                        "NA",                                               "NA"]
+
+def processBuilds(builds) {
+    for (int i = 0; i < builds.size(); i += 4) {
+        def buildConfig = builds[i]
+        def buildTarget = builds[i + 1]
+        sh "nix build -L .#packages.${buildConfig} -o result-${buildTarget}"
+    }
+}
+def processSBOMs(builds) {
+    for (int i = 0; i < builds.size(); i += 4) {
+        def buildConfig = builds[i]
+        def buildTarget = builds[i + 1]
+        def buildSBOMName = builds[i + 2]
+        sh "nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.${buildConfig} --csv ${buildSBOMName}.csv --cdx ${buildSBOMName}cdx.json --spdx ${buildSBOMName}.spdx.json"
+    }
+}
+def processProvenances(builds) {
+    for (int i = 0; i < builds.size(); i += 4) {
+        def buildConfig = builds[i]
+        def buildTarget = builds[i + 1]
+        def buildSBOMName = builds[i + 2]
+        def buildProvenanceName = builds[i + 3]
+        sh "nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.${buildConfig} --recursive --out ${buildProvenanceName}.json"
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 pipeline {
   agent any
   parameters {
@@ -39,24 +83,16 @@ pipeline {
       steps {
         script {
           env.ts_build_begin = sh(script: 'date +%s', returnStdout: true).trim()
-        }
-        dir('ghaf') {
-          sh 'nix build -L .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 -o result-crosscompile-jetson-orin-agx-debug'
-          sh 'nix build -L .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  -o result-crosscompile-jetson-orin-nx-debug'
-          sh 'nix build -L .#packages.x86_64-linux.generic-x86_64-debug                     -o result-generic-x86_64-debug'
-          sh 'nix build -L .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug             -o result-lenovo-x1-carbon-gen11-debug'
-          sh 'nix build -L .#packages.riscv64-linux.microchip-icicle-kit-debug              -o result-microchip-icicle-kit-debug'
-          sh 'nix build -L .#packages.x86_64-linux.doc                                      -o result-doc'
+          dir('ghaf') {
+            processBuilds(builds_x86_64)
+            }
+          }
         }
       }
-    }
     stage('Build on aarch64') {
       steps {
         dir('ghaf') {
-          sh 'nix build -L .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug -o result-aarch64-jetson-orin-agx-debug'
-          sh 'nix build -L .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug  -o result-aarch64-jetson-orin-nx-debug'
-          sh 'nix build -L .#packages.aarch64-linux.imx8qm-mek-debug             -o result-aarch64-imx8qm-mek-debug'
-          sh 'nix build -L .#packages.aarch64-linux.doc                          -o result-aarch64-doc'
+          processBuilds(builds_aarch_64)
         }
         script {
           env.ts_build_finished = sh(script: 'date +%s', returnStdout: true).trim()
@@ -64,68 +100,50 @@ pipeline {
       }
     }
     stage('Provenance') {
-      environment {
-        // TODO: Write our own buildtype and builder id documents
-        PROVENANCE_BUILD_TYPE = "https://docs.cimon.build/provenance/buildtypes/jenkins/v1"
-        PROVENANCE_BUILDER_ID = "https://github.com/tiiuae/ghaf-infra/tree/main/terraform"
-        PROVENANCE_INVOCATION_ID = "${env.JOB_NAME}/${env.BUILD_ID}"
-        PROVENANCE_TIMESTAMP_BEGIN = "${env.ts_build_begin}"
-        PROVENANCE_TIMESTAMP_FINISHED = "${env.ts_build_finished}"
-        PROVENANCE_EXTERNAL_PARAMS = sh(
-          returnStdout: true,
-          script: 'jq -n --arg flakeURI $URL --arg flakeBranch $BRANCH \'$ARGS.named\'' 
-        )
-        PROVENANCE_INTERNAL_PARAMS = sh(
-          returnStdout: true,
-          // returns the specified environment varibles in json format
-          script: """
-            jq -n env | jq "{ \
-              JOB_NAME, \
-              GIT_URL, \
-              GIT_BRANCH, \
-              GIT_COMMIT, \
-            }"
-          """
-        )
-      }
-      steps {
-        dir('ghaf') {
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --recursive --out result-provenance-jetson-orin-agx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  --recursive --out result-provenance-jetson-orin-nx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.generic-x86_64-debug                     --recursive --out result-provenance-generic-x86_64-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug             --recursive --out result-provenance-lenovo-x1-carbon-gen11-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.riscv64-linux.microchip-icicle-kit-debug              --recursive --out result-provenance-microchip-icicle-kit-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug            --recursive --out result-provenance-aarch64-jetson-orin-agx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug             --recursive --out result-provenance-aarch64-jetson-orin-nx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.imx8qm-mek-debug                        --recursive --out result-provenance-aarch64-imx8qm-mek-debug.json'
+          environment {
+            // TODO: Write our own buildtype and builder id documents
+            PROVENANCE_BUILD_TYPE = "https://docs.cimon.build/provenance/buildtypes/jenkins/v1"
+            PROVENANCE_BUILDER_ID = "https://github.com/tiiuae/ghaf-infra/tree/main/terraform"
+            PROVENANCE_INVOCATION_ID = "${env.JOB_NAME}/${env.BUILD_ID}"
+            PROVENANCE_TIMESTAMP_BEGIN = "${env.ts_build_begin}"
+            PROVENANCE_TIMESTAMP_FINISHED = "${env.ts_build_finished}"
+            PROVENANCE_EXTERNAL_PARAMS = sh(
+              returnStdout: true,
+              script: 'jq -n --arg flakeURI $URL --arg flakeBranch $BRANCH \'$ARGS.named\''
+            )
+            PROVENANCE_INTERNAL_PARAMS = sh(
+              returnStdout: true,
+              // returns the specified environment varibles in json format
+              script: """
+                jq -n env | jq "{ \
+                  JOB_NAME, \
+                  GIT_URL, \
+                  GIT_BRANCH, \
+                  GIT_COMMIT, \
+                }"
+              """
+            )
+          }
+          steps {
+            dir('ghaf') {
+              processProvenances(builds_x86_64)
+              processProvenances(builds_aarch_64)
+            }
+          }
         }
-      }
-    }
     stage('SBOM') {
       steps {
         dir('ghaf') {
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --csv result-sbom-crosscompile-jetson-orin-agx-debug.csv --cdx result-sbom-crosscompile-jetson-orin-agx-debug.cdx.json --spdx result-sbom-crosscompile-jetson-orin-agx-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64 --csv result-sbom-crosscompile-jetson-orin-nx-debug.csv --cdx result-sbom-crosscompile-jetson-orin-nx-debug.cdx.json --spdx result-sbom-crosscompile-jetson-orin-nx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.generic-x86_64-debug  --csv result-generic-x86_64-debug.csv --cdx result-generic-x86_64-debugcdx.cdx.json --spdx result-generic-x86_64-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug --csv result-lenovo-x1-carbon-gen11-debug.csv --cdx result-lenovo-x1-carbon-gen11-debug.cdx.json --spdx result-lenovo-x1-carbon-gen11-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.riscv64-linux.microchip-icicle-kit-debug --csv result-microchip-icicle-kit-debug.csv --cdx result-microchip-icicle-kit-debug.cdx.json --spdx result-microchip-icicle-kit-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug --csv result-aarch64-jetson-orin-agx-debug.csv --cdx result-aarch64-jetson-orin-agx-debug.cdx.json --spdx result-aarch64-jetson-orin-agx-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug  --csv result-aarch64-jetson-orin-nx-debug.csv --cdx esult-aarch64-jetson-orin-nx-debug.cdx.json --spdx result-aarch64-jetson-orin-nx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.aarch64-linux.imx8qm-mek-debug   --csv result-aarch64-imx8qm-mek-debug.csv --cdx result-aarch64-imx8qm-mek-debug.cdx.json --spdx result-aarch64-imx8qm-mek-debug.spdx.json'
+          processSBOMs(builds_x86_64)
+          processSBOMs(builds_aarch_64)
         }
       }
     }
     stage('Vulnxscan runtime') {
       steps {
         dir('ghaf') {
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --out result-vulns-jetson-orin-agx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64 --out result-vulns-jetson-orin-nx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.generic-x86_64-debug --out result-vulns-generic-x86_64-debug.csv'
           sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug --out result-vulns-lenovo-x1-carbon-gen11-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.riscv64-linux.microchip-icicle-kit-debug --out result-vulns-microchip-icicle-kit-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug --out result-vulns-aarch64-jetson-orin-agx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug --out result-vulns-aarch64-jetson-orin-nx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.aarch64-linux.imx8qm-mek-debug --out result-vulns-aarch64-imx8qm-mek-debug.csv'
+          sh 'csvcut result-vulns-lenovo-x1-carbon-gen11-debug.csv --not-columns sortcol | csvlook -I > result-vulns-lenovo-x1-carbon-gen11-debug.txt'
         }
       }
     }

--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -33,7 +33,9 @@ def processSBOMs(builds) {
         def buildConfig = builds[i]
         def buildTarget = builds[i + 1]
         def buildSBOMName = builds[i + 2]
-        sh "nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.${buildConfig} --csv ${buildSBOMName}.csv --cdx ${buildSBOMName}cdx.json --spdx ${buildSBOMName}.spdx.json"
+        if (buildSBOMName != "NA") {
+          sh "nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.${buildConfig} --csv ${buildSBOMName}.csv --cdx ${buildSBOMName}cdx.json --spdx ${buildSBOMName}.spdx.json"
+        }
     }
 }
 def processProvenances(builds) {
@@ -42,7 +44,9 @@ def processProvenances(builds) {
         def buildTarget = builds[i + 1]
         def buildSBOMName = builds[i + 2]
         def buildProvenanceName = builds[i + 3]
-        sh "nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.${buildConfig} --recursive --out ${buildProvenanceName}.json"
+        if (buildProvenanceName != "NA") {
+          sh "nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.${buildConfig} --recursive --out ${buildProvenanceName}.json"
+        }
     }
 }
 


### PR DESCRIPTION
Build and analyse commands not typed anymore individually. Targets and output names defined once. Simpler vulnxscan usage (only x1 carbon target ), these results converted to txt format (ghaf infra update already added for csvkit addition)