### PR TITLE
switch to rclone to upload artifacts

### DIFF
--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -133,9 +133,7 @@ pipeline {
   }
   post {
     always {
-      archiveArtifacts allowEmptyArchive: true, artifacts: "ghaf/result-*"
-      archiveArtifacts allowEmptyArchive: true, artifacts: "ghaf/result-*/**"
-      archiveArtifacts allowEmptyArchive: true, artifacts: "ghaf/result-aarch64*/**"
+      sh "RCLONE_WEBDAV_UNIX_SOCKET_PATH=/run/rclone-jenkins-artifacts.sock RCLONE_WEBDAV_URL=http://localhost rclone sync -L 'ghaf/' :webdav:/${env.BUILD_TAG}/ --include '/result-*' --include '/result-*/**'"
     }
   }
 }

--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -134,6 +134,9 @@ pipeline {
   post {
     always {
       sh "RCLONE_WEBDAV_UNIX_SOCKET_PATH=/run/rclone-jenkins-artifacts.sock RCLONE_WEBDAV_URL=http://localhost rclone sync -L 'ghaf/' :webdav:/${env.BUILD_TAG}/ --include '/result-*' --include '/result-*/**'"
+      script {
+        currentBuild.description = "<a href=\"/artifacts/${env.BUILD_TAG}/\" target=\"_blank\">📦 Artifacts</a>"
+      }
     }
   }
 }

--- a/ghaf-nightly-build.groovy
+++ b/ghaf-nightly-build.groovy
@@ -140,9 +140,7 @@ pipeline {
   }
   post {
     always {
-      archiveArtifacts allowEmptyArchive: true, artifacts: "ghaf/result-*"
-      archiveArtifacts allowEmptyArchive: true, artifacts: "ghaf/result-*/**"
-      archiveArtifacts allowEmptyArchive: true, artifacts: "ghaf/result-aarch64*/**"
+      sh "RCLONE_WEBDAV_UNIX_SOCKET_PATH=/run/rclone-jenkins-artifacts.sock RCLONE_WEBDAV_URL=http://localhost rclone sync -L 'ghaf/' :webdav:/${env.BUILD_TAG}/ --include '/result-*' --include '/result-*/**'"
     }
   }
 }

--- a/ghaf-nightly-build.groovy
+++ b/ghaf-nightly-build.groovy
@@ -141,6 +141,9 @@ pipeline {
   post {
     always {
       sh "RCLONE_WEBDAV_UNIX_SOCKET_PATH=/run/rclone-jenkins-artifacts.sock RCLONE_WEBDAV_URL=http://localhost rclone sync -L 'ghaf/' :webdav:/${env.BUILD_TAG}/ --include '/result-*' --include '/result-*/**'"
+      script {
+        currentBuild.description = "<a href=\"/artifacts/${env.BUILD_TAG}/\" target=\"_blank\">📦 Artifacts</a>"
+      }
     }
   }
 }


### PR DESCRIPTION
Requires a Jenkins with https://github.com/tiiuae/ghaf-infra/pull/160 and https://github.com/tiiuae/ghaf-infra/pull/161 applied.

Replaces the `archiveArtifacts` commands with `rclone sync` commands, uploading artifacts to a WebDAV endpoint (backed by Azure Blob Storage on the other side).

Links to the artifact downloads is provided by editing the Build description, as can be seen [here](https://ghaf-jenkins-controller-floklifloklideex.northeurope.cloudapp.azure.com/job/ghaf-pipeline/12/).