### PR TITLE
Update provenance be comply with new buildtype document

### DIFF
--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -33,6 +33,9 @@ pipeline {
             extensions: [cleanBeforeCheckout()],
             userRemoteConfigs: [[url: params.URL]]
           )
+          script {
+            env.TARGET_COMMIT = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
+          }
         }
       }
     }

--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -73,7 +73,9 @@ pipeline {
         PROVENANCE_TIMESTAMP_FINISHED = "${env.ts_build_finished}"
         PROVENANCE_EXTERNAL_PARAMS = sh(
           returnStdout: true,
-          script: "./provenance-external-params.sh"
+          // TODO: Target name should be populated from jenkins, but currently that's not possible 
+          // since the environment is only generated once instead of being unique for every target
+          script: "./provenance-external-params.sh TARGET"
         ).trim()
         PROVENANCE_INTERNAL_PARAMS = ""
       }
@@ -94,13 +96,13 @@ pipeline {
       steps {
         dir('ghaf') {
           sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --csv result-sbom-crosscompile-jetson-orin-agx-debug.csv --cdx result-sbom-crosscompile-jetson-orin-agx-debug.cdx.json --spdx result-sbom-crosscompile-jetson-orin-agx-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64 --csv result-sbom-crosscompile-jetson-orin-nx-debug.csv --cdx result-sbom-crosscompile-jetson-orin-nx-debug.cdx.json --spdx result-sbom-crosscompile-jetson-orin-nx-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.generic-x86_64-debug --csv result-sbom-generic-x86_64-debug.csv --cdx result-sbom-generic-x86_64-debug.cdx.json --spdx result-sbom-generic-x86_64-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug --csv result-sbom-lenovo-x1-carbon-gen11-debug.csv --cdx result-sbom-lenovo-x1-carbon-gen11-debug.cdx.json --spdx result-sbom-lenovo-x1-carbon-gen11-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.riscv64-linux.microchip-icicle-kit-debug --csv result-sbom-microchip-icicle-kit-debug.csv --cdx result-sbom-microchip-icicle-kit-debug.cdx.json --spdx result-sbom-microchip-icicle-kit-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug --csv result-sbom-nxp-imx8mp-evk-debug.csv --cdx result-sbom-nxp-imx8mp-evk-debug.cdx.json --spdx result-sbom-nxp-imx8mp-evk-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug --csv result-sbom-aarch64-jetson-orin-agx-debug.csv --cdx result-sbom-aarch64-jetson-orin-agx-debug.cdx.json --spdx result-sbom-aarch64-jetson-orin-agx-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug --csv result-sbom-aarch64-jetson-orin-nx-debug.csv --cdx result-sbom-aarch64-jetson-orin-nx-debug.cdx.json --spdx result-sbom-aarch64-jetson-orin-nx-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  --csv result-sbom-crosscompile-jetson-orin-nx-debug.csv  --cdx result-sbom-crosscompile-jetson-orin-nx-debug.cdx.json  --spdx result-sbom-crosscompile-jetson-orin-nx-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.generic-x86_64-debug                     --csv result-sbom-generic-x86_64-debug.csv               --cdx result-sbom-generic-x86_64-debug.cdx.json               --spdx result-sbom-generic-x86_64-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug             --csv result-sbom-lenovo-x1-carbon-gen11-debug.csv       --cdx result-sbom-lenovo-x1-carbon-gen11-debug.cdx.json       --spdx result-sbom-lenovo-x1-carbon-gen11-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.riscv64-linux.microchip-icicle-kit-debug              --csv result-sbom-microchip-icicle-kit-debug.csv         --cdx result-sbom-microchip-icicle-kit-debug.cdx.json         --spdx result-sbom-microchip-icicle-kit-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug                    --csv result-sbom-nxp-imx8mp-evk-debug.csv               --cdx result-sbom-nxp-imx8mp-evk-debug.cdx.json               --spdx result-sbom-nxp-imx8mp-evk-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug            --csv result-sbom-aarch64-jetson-orin-agx-debug.csv      --cdx result-sbom-aarch64-jetson-orin-agx-debug.cdx.json      --spdx result-sbom-aarch64-jetson-orin-agx-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug             --csv result-sbom-aarch64-jetson-orin-nx-debug.csv       --cdx result-sbom-aarch64-jetson-orin-nx-debug.cdx.json       --spdx result-sbom-aarch64-jetson-orin-nx-debug.spdx.json'
         }
       }
     }
@@ -108,13 +110,13 @@ pipeline {
       steps {
         dir('ghaf') {
           sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --out result-vulns-jetson-orin-agx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64 --out result-vulns-jetson-orin-nx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.generic-x86_64-debug --out result-vulns-generic-x86_64-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug --out result-vulns-lenovo-x1-carbon-gen11-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.riscv64-linux.microchip-icicle-kit-debug --out result-vulns-microchip-icicle-kit-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug --out result-vulns-nxp-imx8mp-evk-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug --out result-vulns-aarch64-jetson-orin-agx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug --out result-vulns-aarch64-jetson-orin-nx-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  --out result-vulns-jetson-orin-nx-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.generic-x86_64-debug                     --out result-vulns-generic-x86_64-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug             --out result-vulns-lenovo-x1-carbon-gen11-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.riscv64-linux.microchip-icicle-kit-debug              --out result-vulns-microchip-icicle-kit-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug                    --out result-vulns-nxp-imx8mp-evk-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug            --out result-vulns-aarch64-jetson-orin-agx-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug             --out result-vulns-aarch64-jetson-orin-nx-debug.csv'
         }
       }
     }

--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -66,28 +66,16 @@ pipeline {
     }
     stage('Provenance') {
       environment {
-        // TODO: Write our own buildtype and builder id documents
-        PROVENANCE_BUILD_TYPE = "https://docs.cimon.build/provenance/buildtypes/jenkins/v1"
-        PROVENANCE_BUILDER_ID = "https://github.com/tiiuae/ghaf-infra/tree/main/terraform"
-        PROVENANCE_INVOCATION_ID = "${env.JOB_NAME}/${env.BUILD_ID}"
+        PROVENANCE_BUILD_TYPE = "https://github.com/tiiuae/ghaf-infra/blob/c8670cf56a7e891545493891928fac96160a49ea/slsa/v1.0/L1/buildtype.md"
+        PROVENANCE_BUILDER_ID = "${env.JENKINS_URL}"
+        PROVENANCE_INVOCATION_ID = "${env.BUILD_URL}"
         PROVENANCE_TIMESTAMP_BEGIN = "${env.ts_build_begin}"
         PROVENANCE_TIMESTAMP_FINISHED = "${env.ts_build_finished}"
         PROVENANCE_EXTERNAL_PARAMS = sh(
           returnStdout: true,
-          script: 'jq -n --arg flakeURI $URL --arg flakeBranch $BRANCH \'$ARGS.named\''
-        )
-        PROVENANCE_INTERNAL_PARAMS = sh(
-          returnStdout: true,
-          // returns the specified environment varibles in json format
-          script: """
-            jq -n env | jq "{ \
-              JOB_NAME, \
-              GIT_URL, \
-              GIT_BRANCH, \
-              GIT_COMMIT, \
-            }"
-          """
-        )
+          script: "./provenance-external-params.sh"
+        ).trim()
+        PROVENANCE_INTERNAL_PARAMS = ""
       }
       steps {
         dir('ghaf') {

--- a/ghaf-build-pipeline.groovy
+++ b/ghaf-build-pipeline.groovy
@@ -79,42 +79,42 @@ pipeline {
       }
       steps {
         dir('ghaf') {
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --recursive --out result-provenance-jetson-orin-agx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  --recursive --out result-provenance-jetson-orin-nx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.generic-x86_64-debug                     --recursive --out result-provenance-generic-x86_64-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug             --recursive --out result-provenance-lenovo-x1-carbon-gen11-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.riscv64-linux.microchip-icicle-kit-debug              --recursive --out result-provenance-microchip-icicle-kit-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug                    --recursive --out result-provenance-nxp-imx8mp-evk-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug            --recursive --out result-provenance-aarch64-jetson-orin-agx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug             --recursive --out result-provenance-aarch64-jetson-orin-nx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --recursive --out result-provenance-jetson-orin-agx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  --recursive --out result-provenance-jetson-orin-nx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.x86_64-linux.generic-x86_64-debug                     --recursive --out result-provenance-generic-x86_64-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug             --recursive --out result-provenance-lenovo-x1-carbon-gen11-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.riscv64-linux.microchip-icicle-kit-debug              --recursive --out result-provenance-microchip-icicle-kit-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug                    --recursive --out result-provenance-nxp-imx8mp-evk-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug            --recursive --out result-provenance-aarch64-jetson-orin-agx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug             --recursive --out result-provenance-aarch64-jetson-orin-nx-debug.json'
         }
       }
     }
     stage('SBOM') {
       steps {
         dir('ghaf') {
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --csv result-sbom-crosscompile-jetson-orin-agx-debug.csv --cdx result-sbom-crosscompile-jetson-orin-agx-debug.cdx.json --spdx result-sbom-crosscompile-jetson-orin-agx-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64 --csv result-sbom-crosscompile-jetson-orin-nx-debug.csv --cdx result-sbom-crosscompile-jetson-orin-nx-debug.cdx.json --spdx result-sbom-crosscompile-jetson-orin-nx-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.generic-x86_64-debug --csv result-sbom-generic-x86_64-debug.csv --cdx result-sbom-generic-x86_64-debug.cdx.json --spdx result-sbom-generic-x86_64-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug --csv result-sbom-lenovo-x1-carbon-gen11-debug.csv --cdx result-sbom-lenovo-x1-carbon-gen11-debug.cdx.json --spdx result-sbom-lenovo-x1-carbon-gen11-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.riscv64-linux.microchip-icicle-kit-debug --csv result-sbom-microchip-icicle-kit-debug.csv --cdx result-sbom-microchip-icicle-kit-debug.cdx.json --spdx result-sbom-microchip-icicle-kit-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug --csv result-sbom-nxp-imx8mp-evk-debug.csv --cdx result-sbom-nxp-imx8mp-evk-debug.cdx.json --spdx result-sbom-nxp-imx8mp-evk-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug --csv result-sbom-aarch64-jetson-orin-agx-debug.csv --cdx result-sbom-aarch64-jetson-orin-agx-debug.cdx.json --spdx result-sbom-aarch64-jetson-orin-agx-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug --csv result-sbom-aarch64-jetson-orin-nx-debug.csv --cdx result-sbom-aarch64-jetson-orin-nx-debug.cdx.json --spdx result-sbom-aarch64-jetson-orin-nx-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --csv result-sbom-crosscompile-jetson-orin-agx-debug.csv --cdx result-sbom-crosscompile-jetson-orin-agx-debug.cdx.json --spdx result-sbom-crosscompile-jetson-orin-agx-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64 --csv result-sbom-crosscompile-jetson-orin-nx-debug.csv --cdx result-sbom-crosscompile-jetson-orin-nx-debug.cdx.json --spdx result-sbom-crosscompile-jetson-orin-nx-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.generic-x86_64-debug --csv result-sbom-generic-x86_64-debug.csv --cdx result-sbom-generic-x86_64-debug.cdx.json --spdx result-sbom-generic-x86_64-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug --csv result-sbom-lenovo-x1-carbon-gen11-debug.csv --cdx result-sbom-lenovo-x1-carbon-gen11-debug.cdx.json --spdx result-sbom-lenovo-x1-carbon-gen11-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.riscv64-linux.microchip-icicle-kit-debug --csv result-sbom-microchip-icicle-kit-debug.csv --cdx result-sbom-microchip-icicle-kit-debug.cdx.json --spdx result-sbom-microchip-icicle-kit-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug --csv result-sbom-nxp-imx8mp-evk-debug.csv --cdx result-sbom-nxp-imx8mp-evk-debug.cdx.json --spdx result-sbom-nxp-imx8mp-evk-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug --csv result-sbom-aarch64-jetson-orin-agx-debug.csv --cdx result-sbom-aarch64-jetson-orin-agx-debug.cdx.json --spdx result-sbom-aarch64-jetson-orin-agx-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug --csv result-sbom-aarch64-jetson-orin-nx-debug.csv --cdx result-sbom-aarch64-jetson-orin-nx-debug.cdx.json --spdx result-sbom-aarch64-jetson-orin-nx-debug.spdx.json'
         }
       }
     }
     stage('Vulnxscan runtime') {
       steps {
         dir('ghaf') {
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --out result-vulns-jetson-orin-agx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64 --out result-vulns-jetson-orin-nx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.generic-x86_64-debug --out result-vulns-generic-x86_64-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug --out result-vulns-lenovo-x1-carbon-gen11-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.riscv64-linux.microchip-icicle-kit-debug --out result-vulns-microchip-icicle-kit-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug --out result-vulns-nxp-imx8mp-evk-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug --out result-vulns-aarch64-jetson-orin-agx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug --out result-vulns-aarch64-jetson-orin-nx-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --out result-vulns-jetson-orin-agx-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64 --out result-vulns-jetson-orin-nx-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.generic-x86_64-debug --out result-vulns-generic-x86_64-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug --out result-vulns-lenovo-x1-carbon-gen11-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.riscv64-linux.microchip-icicle-kit-debug --out result-vulns-microchip-icicle-kit-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug --out result-vulns-nxp-imx8mp-evk-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug --out result-vulns-aarch64-jetson-orin-agx-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug --out result-vulns-aarch64-jetson-orin-nx-debug.csv'
         }
       }
     }

--- a/ghaf-nightly-build.groovy
+++ b/ghaf-nightly-build.groovy
@@ -33,6 +33,9 @@ pipeline {
             extensions: [cleanBeforeCheckout()],
             userRemoteConfigs: [[url: params.URL]]
           )
+          script {
+            env.TARGET_COMMIT = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
+          }
         }
       }
     }

--- a/ghaf-nightly-build.groovy
+++ b/ghaf-nightly-build.groovy
@@ -66,72 +66,63 @@ pipeline {
     }
     stage('Provenance') {
       environment {
-        // TODO: Write our own buildtype and builder id documents
-        PROVENANCE_BUILD_TYPE = "https://docs.cimon.build/provenance/buildtypes/jenkins/v1"
-        PROVENANCE_BUILDER_ID = "https://github.com/tiiuae/ghaf-infra/tree/main/terraform"
-        PROVENANCE_INVOCATION_ID = "${env.JOB_NAME}/${env.BUILD_ID}"
+        PROVENANCE_BUILD_TYPE = "https://github.com/tiiuae/ghaf-infra/blob/c8670cf56a7e891545493891928fac96160a49ea/slsa/v1.0/L1/buildtype.md"
+        PROVENANCE_BUILDER_ID = "${env.JENKINS_URL}"
+        PROVENANCE_INVOCATION_ID = "${env.BUILD_URL}"
         PROVENANCE_TIMESTAMP_BEGIN = "${env.ts_build_begin}"
         PROVENANCE_TIMESTAMP_FINISHED = "${env.ts_build_finished}"
         PROVENANCE_EXTERNAL_PARAMS = sh(
           returnStdout: true,
-          script: 'jq -n --arg flakeURI $URL --arg flakeBranch $BRANCH \'$ARGS.named\''
-        )
-        PROVENANCE_INTERNAL_PARAMS = sh(
-          returnStdout: true,
-          // returns the specified environment varibles in json format
-          script: """
-            jq -n env | jq "{ \
-              JOB_NAME, \
-              GIT_URL, \
-              GIT_BRANCH, \
-              GIT_COMMIT, \
-            }"
-          """
-        )
+          // TODO: Target name should be populated from jenkins, but currently that's not possible 
+          // since the environment is only generated once instead of being unique for every target
+          script: "./provenance-external-params.sh TARGET"
+        ).trim()
+        PROVENANCE_INTERNAL_PARAMS = ""
       }
       steps {
         dir('ghaf') {
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --recursive --out result-provenance-jetson-orin-agx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  --recursive --out result-provenance-jetson-orin-nx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.generic-x86_64-debug                     --recursive --out result-provenance-generic-x86_64-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug             --recursive --out result-provenance-lenovo-x1-carbon-gen11-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.riscv64-linux.microchip-icicle-kit-debug              --recursive --out result-provenance-microchip-icicle-kit-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug                    --recursive --out result-provenance-nxp-imx8mp-evk-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug            --recursive --out result-provenance-aarch64-jetson-orin-agx-debug.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug             --recursive --out result-provenance-aarch64-jetson-orin-nx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --recursive --out result-provenance-jetson-orin-agx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  --recursive --out result-provenance-jetson-orin-nx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.x86_64-linux.generic-x86_64-debug                     --recursive --out result-provenance-generic-x86_64-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug             --recursive --out result-provenance-lenovo-x1-carbon-gen11-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.riscv64-linux.microchip-icicle-kit-debug              --recursive --out result-provenance-microchip-icicle-kit-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug                    --recursive --out result-provenance-nxp-imx8mp-evk-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug            --recursive --out result-provenance-aarch64-jetson-orin-agx-debug.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#provenance -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug             --recursive --out result-provenance-aarch64-jetson-orin-nx-debug.json'
         }
       }
-    }
+    } 
     stage('SBOM') {
       steps {
         dir('ghaf') {
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --csv result-sbom-crosscompile-jetson-orin-agx-debug.csv --cdx result-sbom-crosscompile-jetson-orin-agx-debug.cdx.json --spdx result-sbom-crosscompile-jetson-orin-agx-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64 --csv result-sbom-crosscompile-jetson-orin-nx-debug.csv --cdx result-sbom-crosscompile-jetson-orin-nx-debug.cdx.json --spdx result-sbom-crosscompile-jetson-orin-nx-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.generic-x86_64-debug --csv result-sbom-generic-x86_64-debug.csv --cdx result-sbom-generic-x86_64-debug.cdx.json --spdx result-sbom-generic-x86_64-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug --csv result-sbom-lenovo-x1-carbon-gen11-debug.csv --cdx result-sbom-lenovo-x1-carbon-gen11-debug.cdx.json --spdx result-sbom-lenovo-x1-carbon-gen11-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.riscv64-linux.microchip-icicle-kit-debug --csv result-sbom-microchip-icicle-kit-debug.csv --cdx result-sbom-microchip-icicle-kit-debug.cdx.json --spdx result-sbom-microchip-icicle-kit-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug --csv result-sbom-nxp-imx8mp-evk-debug.csv --cdx result-sbom-nxp-imx8mp-evk-debug.cdx.json --spdx result-sbom-nxp-imx8mp-evk-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug --csv result-sbom-aarch64-jetson-orin-agx-debug.csv --cdx result-sbom-aarch64-jetson-orin-agx-debug.cdx.json --spdx result-sbom-aarch64-jetson-orin-agx-debug.spdx.json'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug --csv result-sbom-aarch64-jetson-orin-nx-debug.csv --cdx result-sbom-aarch64-jetson-orin-nx-debug.cdx.json --spdx result-sbom-aarch64-jetson-orin-nx-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --csv result-sbom-crosscompile-jetson-orin-agx-debug.csv --cdx result-sbom-crosscompile-jetson-orin-agx-debug.cdx.json --spdx result-sbom-crosscompile-jetson-orin-agx-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  --csv result-sbom-crosscompile-jetson-orin-nx-debug.csv  --cdx result-sbom-crosscompile-jetson-orin-nx-debug.cdx.json  --spdx result-sbom-crosscompile-jetson-orin-nx-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.generic-x86_64-debug                     --csv result-sbom-generic-x86_64-debug.csv               --cdx result-sbom-generic-x86_64-debug.cdx.json               --spdx result-sbom-generic-x86_64-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug             --csv result-sbom-lenovo-x1-carbon-gen11-debug.csv       --cdx result-sbom-lenovo-x1-carbon-gen11-debug.cdx.json       --spdx result-sbom-lenovo-x1-carbon-gen11-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.riscv64-linux.microchip-icicle-kit-debug              --csv result-sbom-microchip-icicle-kit-debug.csv         --cdx result-sbom-microchip-icicle-kit-debug.cdx.json         --spdx result-sbom-microchip-icicle-kit-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug                    --csv result-sbom-nxp-imx8mp-evk-debug.csv               --cdx result-sbom-nxp-imx8mp-evk-debug.cdx.json               --spdx result-sbom-nxp-imx8mp-evk-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug            --csv result-sbom-aarch64-jetson-orin-agx-debug.csv      --cdx result-sbom-aarch64-jetson-orin-agx-debug.cdx.json      --spdx result-sbom-aarch64-jetson-orin-agx-debug.spdx.json'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#sbomnix -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug             --csv result-sbom-aarch64-jetson-orin-nx-debug.csv       --cdx result-sbom-aarch64-jetson-orin-nx-debug.cdx.json       --spdx result-sbom-aarch64-jetson-orin-nx-debug.spdx.json'
         }
       }
-    }
+     }
     stage('Vulnxscan runtime') {
       steps {
         dir('ghaf') {
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --out result-vulns-jetson-orin-agx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64 --out result-vulns-jetson-orin-nx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.generic-x86_64-debug --out result-vulns-generic-x86_64-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug --out result-vulns-lenovo-x1-carbon-gen11-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.riscv64-linux.microchip-icicle-kit-debug --out result-vulns-microchip-icicle-kit-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug --out result-vulns-nxp-imx8mp-evk-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug --out result-vulns-aarch64-jetson-orin-agx-debug.csv'
-          sh 'nix run github:tiiuae/sbomnix/a1f0f88d719687acedd989899ecd7fafab42394c#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug --out result-vulns-aarch64-jetson-orin-nx-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64 --out result-vulns-jetson-orin-agx-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64  --out result-vulns-jetson-orin-nx-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.generic-x86_64-debug                     --out result-vulns-generic-x86_64-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug             --out result-vulns-lenovo-x1-carbon-gen11-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.riscv64-linux.microchip-icicle-kit-debug              --out result-vulns-microchip-icicle-kit-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nxp-imx8mp-evk-debug                    --out result-vulns-nxp-imx8mp-evk-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug            --out result-vulns-aarch64-jetson-orin-agx-debug.csv'
+          sh 'nix run github:tiiuae/sbomnix/0b19e055d1f5124fd67d567db342ef4dd21da6f2#vulnxscan -- .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug             --out result-vulns-aarch64-jetson-orin-nx-debug.csv'
           sh 'csvcut result-vulns-jetson-orin-agx-debug.csv --not-columns sortcol | csvlook -I > result-vulns-jetson-orin-agx-debug.txt'
           sh 'csvcut result-vulns-jetson-orin-nx-debug.csv --not-columns sortcol | csvlook -I > result-vulns-jetson-orin-nx-debug.txt'
           sh 'csvcut result-vulns-generic-x86_64-debug.csv --not-columns sortcol | csvlook -I > result-vulns-generic-x86_64-debug.txt'
           sh 'csvcut result-vulns-lenovo-x1-carbon-gen11-debug.csv --not-columns sortcol | csvlook -I > result-vulns-lenovo-x1-carbon-gen11-debug.txt'
           sh 'csvcut result-vulns-microchip-icicle-kit-debug.csv --not-columns sortcol | csvlook -I > result-vulns-microchip-icicle-kit-debug.txt'
+          sh 'csvcut result-vulns-nxp-imx8mp-evk-debug.csv --not-columns sortcol | csvlook -I > result-vulns-nxp-imx8mp-evk-debug.txt'
           sh 'csvcut result-vulns-aarch64-jetson-orin-agx-debug.csv --not-columns sortcol | csvlook -I > result-vulns-aarch64-jetson-orin-agx-debug.txt'
           sh 'csvcut result-vulns-aarch64-jetson-orin-nx-debug.csv --not-columns sortcol | csvlook -I > result-vulns-aarch64-jetson-orin-nx-debug.txt'
         }

--- a/provenance-external-params.sh
+++ b/provenance-external-params.sh
@@ -6,9 +6,8 @@
 # details of the target being built.
 target=$(jq -n \
     --arg name "$1" \
-    --arg repository \
-    "$URL" --arg ref \
-    "$BRANCH" \
+    --arg repository "$URL" \
+    --arg ref "$TARGET_COMMIT" \
     '$ARGS.named')
 
 # details of the workflow/pipeline repository

--- a/provenance-external-params.sh
+++ b/provenance-external-params.sh
@@ -4,11 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # details of the target being built.
-# TODO: Target name should be populated from jenkins, but currently that's
-# not possible since the environment is only generated once instead of being
-# unique for every target
 target=$(jq -n \
-    --arg name "?" \
+    --arg name "$1" \
     --arg repository \
     "$URL" --arg ref \
     "$BRANCH" \

--- a/provenance-external-params.sh
+++ b/provenance-external-params.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# details of the target being built.
+# TODO: Target name should be populated from jenkins, but currently that's
+# not possible since the environment is only generated once instead of being
+# unique for every target
+target=$(jq -n \
+    --arg name "?" \
+    --arg repository \
+    "$URL" --arg ref \
+    "$BRANCH" \
+    '$ARGS.named')
+
+# details of the workflow/pipeline repository
+workflow=$(jq -n \
+    --arg name "$JOB_NAME" \
+    --arg repository "$GIT_URL" \
+    --arg ref "$GIT_COMMIT" \
+    '$ARGS.named')
+
+# final external parameters is assembled
+jq -n \
+    --argjson target "$target" \
+    --argjson workflow "$workflow" \
+    --arg job "$JOB_NAME" \
+    --arg buildRun "$BUILD_ID" \
+    '$ARGS.named'


### PR DESCRIPTION
external parameters generation moved to a separate file because it was getting long. the script takes target name but can't use it in the current version of this pipeline.