### PR TITLE
Add fast main merge pipeline variant for builds only

### DIFF
--- a/ghaf-merge-main-pipeline
+++ b/ghaf-merge-main-pipeline
@@ -1,0 +1,74 @@
+#!/usr/bin/env groovy
+
+// SPDX-FileCopyrightText: 2024 Technology Innovation Institute (TII)
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pipeline {
+  agent any
+  parameters {
+    string name: 'URL', defaultValue: 'https://github.com/tiiuae/ghaf.git'
+    string name: 'BRANCH', defaultValue: 'main'
+  }
+  triggers {
+    pollSCM '* * * * *'
+  }
+  options {
+    timestamps()
+    disableConcurrentBuilds()
+    buildDiscarder logRotator(
+      artifactDaysToKeepStr: '7',
+      artifactNumToKeepStr: '10',
+      daysToKeepStr: '70',
+      numToKeepStr: '100'
+    )
+  }
+  stages {
+    stage('Checkout') {
+      steps {
+        dir('ghaf') {
+          checkout scmGit(
+            branches: [[name: params.BRANCH]],
+            extensions: [cleanBeforeCheckout()],
+            userRemoteConfigs: [[url: params.URL]]
+          )
+        }
+      }
+    }
+    stage('Build on x86_64') {
+      steps {
+        dir('ghaf') {
+            sh 'nix build -L .#packages.x86_64-linux.generic-x86_64-debug -o result-generic-x86_64-debug'
+            sh 'nix build -L .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug -o result-lenovo-x1-carbon-gen11-debug'
+            sh 'nix build -L .#packages.riscv64-linux.microchip-icicle-kit-debug -o result-microchip-icicle-kit-debug'
+            sh 'nix build -L .#packages.x86_64-linux.doc -o result-doc'
+            sh 'nix build -L .#hydraJobs.nvidia-jetson-orin-agx-debug-bpmp-from-x86_64.x86_64-linux -o result-crosscompile-jetson-orin-agx-debug-bpmp'
+            sh 'nix build -L .#hydraJobs.nvidia-jetson-orin-nx-debug-bpmp-from-x86_64.x86_64-linux -o result-crosscompile-jetson-orin-nx-debug-bpmp'
+            sh 'nix build -L .#hydraJobs.nvidia-jetson-orin-agx-debug-from-x86_64.x86_64-linux -o result-crosscompile-jetson-orin-agx-debug'
+            sh 'nix build -L .#hydraJobs.nvidia-jetson-orin-nx-debug-from-x86_64.x86_64-linux -o result-crosscompile-jetson-orin-nx-debug'
+            sh 'nix build -L .#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug-installer -o result-lenovo-x1-carbon-gen11-debug-installer'
+
+        }
+      }
+    }
+    stage('Build on aarch64') {
+      steps {
+        dir('ghaf') {
+          sh 'nix build -L .#packages.aarch64-linux.nvidia-jetson-orin-agx-debug -o result-aarch64-jetson-orin-agx-debug'
+          sh 'nix build -L .#packages.aarch64-linux.nvidia-jetson-orin-nx-debug  -o result-aarch64-jetson-orin-nx-debug'
+          sh 'nix build -L .#hydraJobs.nvidia-jetson-orin-agx-debug-bpmp.aarch64-linux -o result-aarch64-jetson-orin-agx-debug-bpmp'
+          sh 'nix build -L .#hydraJobs.nvidia-jetson-orin-nx-debug-bpmp.aarch64-linux -o result-aarch64-jetson-orin-nx-debug-bpmp'
+        }
+      }
+    }
+
+  }
+  post {
+    always {
+      sh "RCLONE_WEBDAV_UNIX_SOCKET_PATH=/run/rclone-jenkins-artifacts.sock RCLONE_WEBDAV_URL=http://localhost rclone sync -L 'ghaf/' :webdav:/${env.BUILD_TAG}/ --include '/result-*' --include '/result-*/**'"
+      script {
+        currentBuild.description = "<a href=\"/artifacts/${env.BUILD_TAG}/\" target=\"_blank\">📦 Artifacts</a>"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Build only required variants, no analyse or other after build steps. Aimed to be build after every Ghaf main merge operations.  