### PR TITLE
Support stashing build results

### DIFF
--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -38,7 +38,7 @@ pipeline {
           )
           script {
             env.TARGET_COMMIT = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
-            env.ARTIFACTS_RELPATH = "${env.JOB_NAME}/build_${env.BUILD_ID}-commit_${env.TARGET_COMMIT}"
+            env.ARTIFACTS_REMOTE_PATH = "${env.JOB_NAME}/build_${env.BUILD_ID}-commit_${env.TARGET_COMMIT}"
           }
         }
       }
@@ -47,10 +47,10 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            utils.nix_build('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'out')
-            utils.nix_build('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'out')
-            utils.nix_build('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'out')
-            utils.nix_build('.#packages.riscv64-linux.microchip-icicle-kit-debug', 'out')
+            utils.nix_build('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'archive')
+            utils.nix_build('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'archive')
+            utils.nix_build('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'archive')
+            utils.nix_build('.#packages.riscv64-linux.microchip-icicle-kit-debug', 'archive')
             utils.nix_build('.#packages.x86_64-linux.doc')
           }
         }
@@ -60,24 +60,11 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            utils.nix_build('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'out')
-            utils.nix_build('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'out')
+            utils.nix_build('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'archive')
+            utils.nix_build('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'archive')
             utils.nix_build('.#packages.aarch64-linux.doc')
           }
         }
-      }
-    }
-  }
-  post {
-    always {
-      // Archive nix build results from the builds that produced out-links
-      sh """
-        export RCLONE_WEBDAV_UNIX_SOCKET_PATH=/run/rclone-jenkins-artifacts.sock
-        export RCLONE_WEBDAV_URL=http://localhost
-        rclone sync -L ${WORKDIR}/build/ :webdav:/${env.ARTIFACTS_RELPATH}/
-      """
-      script {
-        currentBuild.description = "<a href=\"/artifacts/${env.ARTIFACTS_RELPATH}/\">📦 Artifacts</a>"
       }
     }
   }

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -44,7 +44,7 @@ pipeline {
           script {
             env.TARGET_REPO = sh(script: 'git remote get-url origin', returnStdout: true).trim()
             env.TARGET_COMMIT = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
-            env.ARTIFACTS_RELPATH = "${env.JOB_NAME}/build_${env.BUILD_ID}-commit_${env.TARGET_COMMIT}"
+            env.ARTIFACTS_REMOTE_PATH = "${env.JOB_NAME}/build_${env.BUILD_ID}-commit_${env.TARGET_COMMIT}"
           }
         }
       }
@@ -53,12 +53,12 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            utils.nix_build('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'out')
-            utils.nix_build('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'out')
-            utils.nix_build('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'out')
-            utils.nix_build('.#packages.riscv64-linux.microchip-icicle-kit-debug', 'out')
-            utils.nix_build('.#hydraJobs.nvidia-jetson-orin-agx-debug-bpmp-from-x86_64.x86_64-linux', 'out')
-            utils.nix_build('.#hydraJobs.nvidia-jetson-orin-nx-debug-bpmp-from-x86_64.x86_64-linux', 'out')
+            utils.nix_build('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'archive')
+            utils.nix_build('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'archive')
+            utils.nix_build('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'archive')
+            utils.nix_build('.#packages.riscv64-linux.microchip-icicle-kit-debug', 'archive')
+            utils.nix_build('.#hydraJobs.nvidia-jetson-orin-agx-debug-bpmp-from-x86_64.x86_64-linux', 'archive')
+            utils.nix_build('.#hydraJobs.nvidia-jetson-orin-nx-debug-bpmp-from-x86_64.x86_64-linux', 'archive')
             utils.nix_build('.#packages.x86_64-linux.doc')
           }
         }
@@ -68,11 +68,11 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            utils.nix_build('.#packages.aarch64-linux.nxp-imx8mp-evk-debug', 'out')
-            utils.nix_build('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'out')
-            utils.nix_build('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'out')
-            utils.nix_build('.#hydraJobs.nvidia-jetson-orin-agx-debug-bpmp.aarch64-linux', 'out')
-            utils.nix_build('.#hydraJobs.nvidia-jetson-orin-nx-debug-bpmp.aarch64-linux', 'out')
+            utils.nix_build('.#packages.aarch64-linux.nxp-imx8mp-evk-debug', 'archive')
+            utils.nix_build('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'archive')
+            utils.nix_build('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'archive')
+            utils.nix_build('.#hydraJobs.nvidia-jetson-orin-agx-debug-bpmp.aarch64-linux', 'archive')
+            utils.nix_build('.#hydraJobs.nvidia-jetson-orin-nx-debug-bpmp.aarch64-linux', 'archive')
             utils.nix_build('.#packages.aarch64-linux.doc')
           }
         }
@@ -121,22 +121,6 @@ pipeline {
             utils.sbomnix('vulnxscan', '.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug')
           }
         }
-      }
-    }
-  }
-  post {
-    always {
-      // Archive nix build results from the builds that produced out-links,
-      // also, archive the scs outputs (provenance, sbom, vulnxscan) under
-      // the same storage path
-      sh """
-        export RCLONE_WEBDAV_UNIX_SOCKET_PATH=/run/rclone-jenkins-artifacts.sock
-        export RCLONE_WEBDAV_URL=http://localhost
-        rclone sync -L ${WORKDIR}/build/ :webdav:/${env.ARTIFACTS_RELPATH}/
-        rclone copy -L ${WORKDIR}/scs/ :webdav:/${env.ARTIFACTS_RELPATH}/
-      """
-      script {
-        currentBuild.description = "<a href=\"/artifacts/${env.ARTIFACTS_RELPATH}/\">📦 Artifacts</a>"
       }
     }
   }

--- a/utils.groovy
+++ b/utils.groovy
@@ -33,7 +33,7 @@ def archive_artifacts(String subdir) {
     return
   } else if (subdir == "stash") {
     // 'stash' subdir is a special case indicating the artifacts under
-    // that directory are temporary, and will be removed latest
+    // that directory are temporary, and will (might) be manually removed
     // at the end of the pipeline. For that reason, no artifacts link
     // will be set in the build description.
     if (!env.STASH_REMOTE_PATH) {
@@ -55,7 +55,7 @@ def archive_artifacts(String subdir) {
 
 def purge_stash(String remote_path) {
   if (!remote_path) {
-    printlf "Warning: skipping stash purge, remote_path not set"
+    println "Warning: skipping stash purge, remote_path not set"
     return
   }
   run_rclone("purge :webdav:/${remote_path}")


### PR DESCRIPTION
- Support storing build results in a temporary per-build 'stash' storage which is manually removed in a post step. This feature will be later used in HW-testing to support downloading build images to the test agent to enable HW-testing in cases where the triggering pipeline otherwise does not store artifacts.
- Move artifact archiving so it's done during the call to `nix_build` function if requested, rather than as a manual step in each pipeline.
- Add explicit argument types to `utils.groovy` functions. 
- Add other helper functions to `utils.groovy`, which will soon be used in pipelines that trigger HW-tests. For reference of the anticipated usage, see the dummy test pipelines at: https://github.com/tiiuae/ghaf-jenkins-pipeline/commit/b57b704859b1ed0bd01ff8481f527b8d369b2739.