### PR TITLE
Add initial boot test pipeline

### DIFF
--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -71,22 +71,9 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            imgdir = utils.find_img_relpath('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'archive')
-            remote_path = "artifacts/${env.ARTIFACTS_REMOTE_PATH}"
             jenkins_url = "https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com"
-            img_url = "${jenkins_url}/${remote_path}/${imgdir}"
-            // Trigger a build in 'ghaf-test-boot' pipeline.
-            // 'build' step is documented in https://plugins.jenkins.io/pipeline-build-step/
-            build(
-              job: "ghaf-test-boot",
-              propagate: true,
-              parameters: [
-                string(name: "LABEL", value: "testagent"),
-                string(name: "DEVICE_CONFIG_NAME", value: "orin-agx"),
-                string(name: "IMG_URL", value: "$img_url"),
-              ],
-              wait: true,
-            )
+            utils.boot_test('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'orin-agx', jenkins_url)
+            utils.boot_test('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'orin-agx', jenkins_url)
           }
         }
       }

--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -67,6 +67,30 @@ pipeline {
         }
       }
     }
+    stage('Boot test') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            imgdir = utils.find_img_relpath('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'archive')
+            remote_path = "artifacts/${env.ARTIFACTS_REMOTE_PATH}"
+            jenkins_url = "https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com"
+            img_url = "${jenkins_url}/${remote_path}/${imgdir}"
+            // Trigger a build in 'ghaf-test-boot' pipeline.
+            // 'build' step is documented in https://plugins.jenkins.io/pipeline-build-step/
+            build(
+              job: "ghaf-test-boot",
+              propagate: true,
+              parameters: [
+                string(name: "LABEL", value: "testagent"),
+                string(name: "DEVICE_CONFIG_NAME", value: "orin-agx"),
+                string(name: "IMG_URL", value: "$img_url"),
+              ],
+              wait: true,
+            )
+          }
+        }
+      }
+    }
   }
 }
 

--- a/ghaf-pre-merge-pipeline.groovy
+++ b/ghaf-pre-merge-pipeline.groovy
@@ -104,7 +104,6 @@ pipeline {
           )
           script {
             env.TARGET_COMMIT = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
-            env.STASH_REMOTE_PATH = "stash/${env.BUILD_TAG}-commit_${env.TARGET_COMMIT}"
           }
         }
       }
@@ -138,11 +137,7 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            // Temporarily store the agx build result (image) to 'stash'.
-            // The stash is currently not used, but this is an example showing
-            // how to make the image available for HW-testing, without
-            // permanently archiving the build output to artifact storage.
-            utils.nix_build('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'stash')
+            utils.nix_build('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug')
             utils.nix_build('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug')
             utils.nix_build('.#packages.aarch64-linux.doc')
           }
@@ -151,14 +146,6 @@ pipeline {
     }
   }
   post {
-    always {
-      script {
-        if(utils) {
-          // Remove temporary, stashed build results before exiting the pipeline
-          utils.purge_stash(env.STASH_REMOTE_PATH)
-        }
-      }
-    }
     success {
       script {
         setGitHubPullRequestStatus(

--- a/ghaf-test-boot.groovy
+++ b/ghaf-test-boot.groovy
@@ -1,0 +1,148 @@
+#!/usr/bin/env groovy
+
+// SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+
+////////////////////////////////////////////////////////////////////////////////
+
+def REPO_URL = 'https://github.com/tiiuae/ci-test-automation/'
+def DEF_LABEL = 'testagent'
+def TMP_IMG_DIR = 'image'
+
+////////////////////////////////////////////////////////////////////////////////
+
+def run_cmd(String cmd) {
+  // Run cmd returning stdout
+  return sh(script: cmd, returnStdout:true).trim()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+pipeline {
+  agent { label "${params.getOrDefault('LABEL', DEF_LABEL)}" }
+  options { timestamps () }
+  stages {
+    stage('Checkout') {
+      steps {
+        checkout scmGit(
+          branches: [[name: 'main']],
+          extensions: [cleanBeforeCheckout()],
+          userRemoteConfigs: [[url: REPO_URL]]
+        )
+        script {
+          sh 'rm -f Robot-Framework/config/*.json'
+          sh 'ln -sv /etc/jenkins/test_config.json Robot-Framework/config'
+          sh """
+            echo { \\\"Job\\\": \\\"${BUILD_NUMBER}\\\" } > Robot-Framework/config/${BUILD_NUMBER}.json
+          """
+        }
+      }
+    }
+    stage('Image download') {
+      steps {
+        script {
+          if (!params.containsKey('IMG_URL')) {
+            println "Missing IMG_URL parameter"
+            exit 1
+          }
+          sh "rm -fr ${TMP_IMG_DIR}"
+          sh "wget -nv --show-progress --progress=dot:giga -P ${TMP_IMG_DIR} ${params.IMG_URL}"
+          img_relpath = run_cmd("find ${TMP_IMG_DIR} -type f -print -quit | grep .")
+          println "Downloaded image to workspace: ${img_relpath}"
+          // Uncompress, keeping only the decompressed image file
+          if(img_relpath.endsWith("zst")) {
+            sh "zstd -dfv ${img_relpath} && rm ${img_relpath}"
+          }
+          sh "ls -la ${TMP_IMG_DIR}"
+        }
+      }
+    }
+    stage('Flash') {
+      steps {
+        script {
+          if(!params.getOrDefault('DEVICE_CONFIG_NAME', null)) {
+            println "Missing DEVICE_CONFIG_NAME parameter"
+            exit 1
+          }
+          mount_cmd = unmount_cmd = devstr = null
+          if(["orin-agx"].contains(params.DEVICE_CONFIG_NAME)) {
+            mount_cmd = '/run/wrappers/bin/sudo AcronameHubCLI -u 0 -s 0x2954223B; sleep 10'
+            unmount_cmd = '/run/wrappers/bin/sudo AcronameHubCLI -u 1 -s 0x2954223B'
+            devstr = 'PSSD'
+            // Device-sepcific configuration needed in other steps are passed
+            // as environment variables
+            env.DEVICE = 'OrinAGX1'
+            env.INCLUDE_TEST_TAGS = 'bootANDorin-agx'
+          } else {
+            println "Error: unsupported device config '${params.DEVICE_CONFIG_NAME}'"
+            sh "exit 1"
+          }
+          // Mount the target disk
+          sh "${mount_cmd}"
+          // Read the device name
+          dev = run_cmd("lsblk -o model,name | grep ${devstr} | rev | cut -d ' ' -f 1 | rev | grep .")
+          println "Using device '$dev'"
+          // Write the image
+          img_relpath = run_cmd("find ${TMP_IMG_DIR} -type f -print -quit | grep .")
+          println "Using image '$img_relpath'"
+          sh "/run/wrappers/bin/sudo dd if=${img_relpath} of=/dev/${dev} bs=1M status=progress conv=fsync"
+          // Unmount
+          sh "${unmount_cmd}"
+        }
+      }
+    }
+    stage('Boot test') {
+      steps {
+        script {
+        // TODO: do we really need credentials to access the target devices?
+        // Target devices are connected to the testagent, which itself is
+        // only available over a private network. What is the risk
+        // we are protecting against by having additional authentication
+        // for the test devices?
+        // The current configuration requires additional manual configuration
+        // on the jenkins UI to add the following secrets:
+        withCredentials([
+          string(credentialsId: 'testagent-dut-pass', variable: 'DUT_PASS'),
+          string(credentialsId: 'testagent-plug-pass', variable: 'PLUG_PASS'),
+          ]) {
+            dir('Robot-Framework/test-suites') {
+              sh 'rm -f *.png output.xml report.html log.html'
+              // Pass the secrets to the shell as environment variables, as we
+              // don't want Groovy to interpolate them. Similary, we pass
+              // other variables as environment variables to shell.
+              // Ref: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation
+              sh '''
+                nix run .#ghaf-robot -- \
+                  -v DEVICE:$DEVICE \
+                  -v LOGIN:ghaf \
+                  -v PASSWORD:$DUT_PASS \
+                  -v PLUG_USERNAME:ville-pekka.juntunen@unikie.com \
+                  -v PLUG_PASSWORD:$PLUG_PASS \
+                  -i $INCLUDE_TEST_TAGS .
+              '''
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    always {
+      step(
+        [$class: 'RobotPublisher',
+          archiveDirName: 'robot-plugin',
+          outputPath: 'Robot-Framework/test-suites',
+          outputFileName: 'output.xml',
+          disableArchiveOutput: false,
+          reportFileName: 'report.html',
+          logFileName: 'log.html',
+          passThreshold: 0,
+          unstableThreshold: 0,
+          onlyCritical: true,
+        ]
+      )
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/ghaf-test-boot.groovy
+++ b/ghaf-test-boot.groovy
@@ -38,12 +38,23 @@ pipeline {
         }
       }
     }
+    stage('Set description') {
+      steps {
+        script {
+          if(!params.containsKey('DESC')) {
+            println "Missing DESC parameter, skip setting description"
+          } else {
+            currentBuild.description = "${params.DESC}"
+          }
+        }
+      }
+    }
     stage('Image download') {
       steps {
         script {
-          if (!params.containsKey('IMG_URL')) {
+          if(!params.containsKey('IMG_URL')) {
             println "Missing IMG_URL parameter"
-            exit 1
+            sh "exit 1"
           }
           sh "rm -fr ${TMP_IMG_DIR}"
           sh "wget -nv --show-progress --progress=dot:giga -P ${TMP_IMG_DIR} ${params.IMG_URL}"
@@ -62,7 +73,7 @@ pipeline {
         script {
           if(!params.getOrDefault('DEVICE_CONFIG_NAME', null)) {
             println "Missing DEVICE_CONFIG_NAME parameter"
-            exit 1
+            sh "exit 1"
           }
           mount_cmd = unmount_cmd = devstr = null
           if(["orin-agx"].contains(params.DEVICE_CONFIG_NAME)) {

--- a/utils.groovy
+++ b/utils.groovy
@@ -143,13 +143,19 @@ def sbomnix(String tool, String flakeref) {
 
 def find_img_relpath(String flakeref, String subdir) {
   flakeref_trimmed = "${flakeref_trim(flakeref)}"
-  imgdir = sh(
+  img_relpath = sh(
     script: """
       cd ${subdir} && \
-      find -L ${flakeref_trimmed} -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)' -print -quit
+      find -L ${flakeref_trimmed} -regex '.*\\.\\(img\\|raw\\|zst\\|iso\\)\$' -print -quit
     """, returnStdout: true).trim()
-  println "Found flakeref '${flakeref}' img: '${imgdir}'"
-  return imgdir
+  if(!img_relpath) {
+    // Error out stopping the pipeline execution if image was not found
+    println "Error: no image found from '${subdir}/${flakeref_trimmed}'"
+    sh "exit 1"
+  } else {
+    println "Found flakeref '${flakeref}' image '${img_relpath}'"
+  }
+  return img_relpath
 }
 
 return this

--- a/utils.groovy
+++ b/utils.groovy
@@ -162,6 +162,11 @@ def boot_test(String flakeref, String device_config, String jenkins_url, String 
   imgdir = find_img_relpath(flakeref, subdir)
   remote_path = "artifacts/${env.ARTIFACTS_REMOTE_PATH}"
   img_url = "${jenkins_url}/${remote_path}/${imgdir}"
+  build_url = "${jenkins_url}/job/${env.JOB_NAME}/${env.BUILD_ID}"
+  build_href = "<a href=\"${build_url}\">#${env.BUILD_ID}</a>"
+  // 'short' flakeref: everything after the last occurence of '.' (if any)
+  flakeref_short = flakeref_trim(flakeref).replaceAll(/.*\.+/,"")
+  description = "Triggered by upstream build ${build_href}<br>(${flakeref_short})"
   // Trigger a build in 'ghaf-test-boot' pipeline.
   // 'build' step is documented in https://plugins.jenkins.io/pipeline-build-step/
   build(
@@ -171,6 +176,7 @@ def boot_test(String flakeref, String device_config, String jenkins_url, String 
       string(name: "LABEL", value: "testagent"),
       string(name: "DEVICE_CONFIG_NAME", value: "$device_config"),
       string(name: "IMG_URL", value: "$img_url"),
+      string(name: "DESC", value: "$description"),
     ],
     wait: true,
   )

--- a/utils.groovy
+++ b/utils.groovy
@@ -163,10 +163,10 @@ def boot_test(String flakeref, String device_config, String jenkins_url, String 
   remote_path = "artifacts/${env.ARTIFACTS_REMOTE_PATH}"
   img_url = "${jenkins_url}/${remote_path}/${imgdir}"
   build_url = "${jenkins_url}/job/${env.JOB_NAME}/${env.BUILD_ID}"
-  build_href = "<a href=\"${build_url}\">#${env.BUILD_ID}</a>"
+  build_href = "<a href=\"${build_url}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
   // 'short' flakeref: everything after the last occurence of '.' (if any)
   flakeref_short = flakeref_trim(flakeref).replaceAll(/.*\.+/,"")
-  description = "Triggered by upstream build ${build_href}<br>(${flakeref_short})"
+  description = "Triggered by ${build_href}<br>(${flakeref_short})"
   // Trigger a build in 'ghaf-test-boot' pipeline.
   // 'build' step is documented in https://plugins.jenkins.io/pipeline-build-step/
   build(

--- a/utils.groovy
+++ b/utils.groovy
@@ -31,26 +31,15 @@ def archive_artifacts(String subdir) {
   if (!subdir) {
     println "Warning: skipping archive, subdir not set"
     return
-  } else if (subdir == "stash") {
-    // 'stash' subdir is a special case indicating the artifacts under
-    // that directory are temporary, and will (might) be manually removed
-    // at the end of the pipeline. For that reason, no artifacts link
-    // will be set in the build description.
-    if (!env.STASH_REMOTE_PATH) {
-      println "Warning: skipping archive, STASH_REMOTE_PATH not set"
-      return
-    }
-    run_rclone("copy -L ${subdir}/ :webdav:/${env.STASH_REMOTE_PATH}/")
-  } else {
-    // All other subdirs are archived to env.ARTIFACTS_REMOTE_PATH
-    if (!env.ARTIFACTS_REMOTE_PATH) {
-      println "Warning: skipping archive, ARTIFACTS_REMOTE_PATH not set"
-      return
-    }
-    run_rclone("copy -L ${subdir}/ :webdav:/${env.ARTIFACTS_REMOTE_PATH}/")
-    href="/artifacts/${env.ARTIFACTS_REMOTE_PATH}/"
-    currentBuild.description = "<a href=\"${href}\">📦 Artifacts</a>"
   }
+  // Archive artifacts to env.ARTIFACTS_REMOTE_PATH
+  if (!env.ARTIFACTS_REMOTE_PATH) {
+    println "Warning: skipping archive, ARTIFACTS_REMOTE_PATH not set"
+    return
+  }
+  run_rclone("copy -L ${subdir}/ :webdav:/${env.ARTIFACTS_REMOTE_PATH}/")
+  href="/artifacts/${env.ARTIFACTS_REMOTE_PATH}/"
+  currentBuild.description = "<a href=\"${href}\">📦 Artifacts</a>"
 }
 
 def purge_stash(String remote_path) {


### PR DESCRIPTION
This PR introduces 'ghaf-test-boot' pipeline which can be used to run the HW boot-tests (currently, only on orin-agx hardware). This change also takes the boot-test into use in the 'ghaf-main-pipeline'.

Using the pipeline introduced in this PR requires having the jenkins-controller VM changes from: https://github.com/tiiuae/ghaf-infra/pull/185.

Note: running the HW-tests requires setting-up a testagent as described in: https://ssrc.atlassian.net/wiki/x/IoAXRQ - currently, such testagent setup will be done on the 'dev' instance. Other instances are still able to run the pipelines, but the HW-tests will obviously not be run.

Also note: If possible, I would eventually like to get rid of the authentication that's now [required to access the test device](https://github.com/tiiuae/ghaf-jenkins-pipeline/blob/824947813f30903ca4152dfd0ed85c5c14d6a03c/ghaf-test-boot.groovy#L108-L114). Currently, while we need such authentication, we need to also manually configure the secrets 'testagent-dut-pass' and 'testagent-plug-pass' on the 'dev' Jenkins instance to be able to run the HW-tests as explained in: https://ssrc.atlassian.net/wiki/spaces/SP/pages/1159168034/Test+setup+for+ghaf-infra+testagent#Configuring-Boot-Test-Credentials.

The changes from this PR have been tested in a private ghaf-infra deployment, see: https://ghaf-jenkins-controller-henrirosten.northeurope.cloudapp.azure.com/job/ghaf-main-pipeline/ and https://ghaf-jenkins-controller-henrirosten.northeurope.cloudapp.azure.com/job/ghaf-test-boot/.