### PR TITLE
Add possibility to slack failed dev build info

### DIFF
--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -79,6 +79,29 @@ pipeline {
       }
     }
   }
+
+  post {
+    failure {
+      script {
+        githublink="https://github.com/tiiuae/ghaf/commit/${env.TARGET_COMMIT}"
+        servername = sh(script: 'uname -n', returnStdout: true).trim()
+        echo "Server name:$servername"
+        if (servername=="ghaf-jenkins-controller-dev") {
+          serverchannel="ghaf-jenkins-builds-failed"
+          echo "Slack channel:$serverchannel"
+          message= "FAIL build: ${servername} ${env.JOB_NAME} [${env.BUILD_NUMBER}] (<${githublink}|The commits>)  (<${env.BUILD_URL}|The Build>)"
+          slackSend (
+            channel: "$serverchannel",
+            color: '#36a64f', // green
+            message: message
+          )
+        }
+        else {
+          echo "Slack message not sent (failed build). Check pipeline slack configuration!"
+        }
+      }
+    }
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
New PR top of current pipeline status merged: add possibility to slack dev jenkins failed builds. One need only add configured channel to slack app for following