### PR TITLE
Disable concurrent builds in pipelines

### DIFF
--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -23,6 +23,7 @@ pipeline {
      pollSCM('* * * * *')
   }
   options {
+    disableConcurrentBuilds()
     timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -28,6 +28,7 @@ pipeline {
      pollSCM('0 23 * * *')
   }
   options {
+    disableConcurrentBuilds()
     timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }

--- a/ghaf-pre-merge-pipeline.groovy
+++ b/ghaf-pre-merge-pipeline.groovy
@@ -48,6 +48,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
+    disableConcurrentBuilds()
     timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }


### PR DESCRIPTION
Set `disableConcurrentBuilds()` option on pipelines that did not explicitly set it yet. This is need to prevent the issue descibed in https://ssrc.atlassian.net/browse/SP-4957.