### PR TITLE
Add build target: generic-x86_64-debug

### DIFF
--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -52,6 +52,8 @@ pipeline {
             utils.nix_build('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'archive')
             utils.nix_build('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'archive')
             utils.nix_build('.#packages.riscv64-linux.microchip-icicle-kit-debug', 'archive')
+            // Build, but don't archive the build results:
+            utils.nix_build('.#packages.x86_64-linux.generic-x86_64-debug')
             utils.nix_build('.#packages.x86_64-linux.doc')
           }
         }

--- a/ghaf-pre-merge-pipeline.groovy
+++ b/ghaf-pre-merge-pipeline.groovy
@@ -128,6 +128,7 @@ pipeline {
             utils.nix_build('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64')
             utils.nix_build('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64')
             utils.nix_build('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug')
+            utils.nix_build('.#packages.x86_64-linux.generic-x86_64-debug')
             utils.nix_build('.#packages.riscv64-linux.microchip-icicle-kit-debug')
             utils.nix_build('.#packages.x86_64-linux.doc')
           }


### PR DESCRIPTION
Add Ghaf build target `generic-x86_64-debug` to main and pre-merge pipelines. Intentionally do not archive the generic image (currently, its not zipped so each archived generic image takes around 11GB of disk space (or blob storage)).

No need to add it to nightly pipeline either, since it already includes the generic target.

For reference: https://github.com/tiiuae/ghaf/pull/729.
