### PR TITLE
Allow running full HW test set

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -46,7 +46,11 @@ def ghaf_robot_test(String testname='boot') {
     string(credentialsId: 'testagent-switch-secret', variable: 'SW_SECRET'),
   ]) {
     dir('Robot-Framework/test-suites') {
-      env.INCLUDE_TEST_TAGS = "${testname}AND${env.DEVICE_TAG}"
+      if (testname == 'turnoff') {
+        env.INCLUDE_TEST_TAGS = "${testname}"
+      } else {
+        env.INCLUDE_TEST_TAGS = "${testname}AND${env.DEVICE_TAG}"
+      }
       sh 'rm -f *.png output.xml report.html log.html'
       // On failure, continue the pipeline execution
       catchError(stageResult: 'FAILURE', buildResult: 'FAILURE') {
@@ -208,6 +212,13 @@ pipeline {
       steps {
         script {
           ghaf_robot_test('performance')
+        }
+      }
+    }
+    stage('Turn off') {
+      steps {
+        script {
+          ghaf_robot_test('turnoff')
         }
       }
     }

--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -70,16 +70,16 @@ pipeline {
         }
       }
     }
-    stage('Boot test') {
+    stage('HW test') {
       steps {
         dir(WORKDIR) {
           script {
             jenkins_url = "https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com"
-            utils.boot_test('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'orin-agx', jenkins_url)
-            utils.boot_test('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'orin-agx', jenkins_url)
-            utils.boot_test('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'orin-nx', jenkins_url)
-            utils.boot_test('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'orin-nx', jenkins_url)
-            utils.boot_test('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'lenovo-x1', jenkins_url)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'orin-agx', jenkins_url)
+            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'orin-agx', jenkins_url)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'orin-nx', jenkins_url)
+            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'orin-nx', jenkins_url)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'lenovo-x1', jenkins_url)
           }
         }
       }

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -80,6 +80,21 @@ pipeline {
         }
       }
     }
+    stage('HW test') {
+      steps {
+        dir(WORKDIR) {
+          script {
+            jenkins_url = "https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com"
+            testset = "_boot_bat_perf_"
+            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'orin-agx', jenkins_url, testset)
+            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'orin-agx', jenkins_url, testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'orin-nx', jenkins_url, testset)
+            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'orin-nx', jenkins_url, testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'lenovo-x1', jenkins_url, testset)
+          }
+        }
+      }
+    }
     stage('Provenance') {
       steps {
         dir(WORKDIR) {

--- a/utils.groovy
+++ b/utils.groovy
@@ -147,7 +147,8 @@ def find_img_relpath(String flakeref, String subdir) {
   return img_relpath
 }
 
-def boot_test(String flakeref, String device_config, String jenkins_url, String subdir='archive') {
+def ghaf_hw_test(String flakeref, String device_config, String jenkins_url, String testset='_boot_')
+  {
   testagent_nodes = nodesByLabel(label: 'testagent', offline: false)
   if (!testagent_nodes) {
     println "Warning: Skipping boot test '$flakeref', no test agents online"
@@ -159,7 +160,7 @@ def boot_test(String flakeref, String device_config, String jenkins_url, String 
     return
   }
   // Compose the image URL; testagent will need this URL to download the image
-  imgdir = find_img_relpath(flakeref, subdir)
+  imgdir = find_img_relpath(flakeref, 'archive')
   remote_path = "artifacts/${env.ARTIFACTS_REMOTE_PATH}"
   img_url = "${jenkins_url}/${remote_path}/${imgdir}"
   build_url = "${jenkins_url}/job/${env.JOB_NAME}/${env.BUILD_ID}"
@@ -167,16 +168,17 @@ def boot_test(String flakeref, String device_config, String jenkins_url, String 
   // 'short' flakeref: everything after the last occurence of '.' (if any)
   flakeref_short = flakeref_trim(flakeref).replaceAll(/.*\.+/,"")
   description = "Triggered by ${build_href}<br>(${flakeref_short})"
-  // Trigger a build in 'ghaf-test-boot' pipeline.
+  // Trigger a build in 'ghaf-hw-test' pipeline.
   // 'build' step is documented in https://plugins.jenkins.io/pipeline-build-step/
   build(
-    job: "ghaf-test-boot",
+    job: "ghaf-hw-test",
     propagate: true,
     parameters: [
       string(name: "LABEL", value: "testagent"),
       string(name: "DEVICE_CONFIG_NAME", value: "$device_config"),
       string(name: "IMG_URL", value: "$img_url"),
       string(name: "DESC", value: "$description"),
+      string(name: "TESTSET", value: "$testset"),
     ],
     wait: true,
   )


### PR DESCRIPTION
- Support running full HW test set (boot, bat, performance) on jenkins pipeline
- Allow selecting a subset of tests per HW test job
- Run the full HW testset as part of nightly build pipeline
- Turn off the device at the end of HW test pipeline