### PR TITLE
Add riscv HW tests to main and nightly pipeline

### DIFF
--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -80,6 +80,7 @@ pipeline {
             utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'orin-nx', jenkins_url)
             utils.ghaf_hw_test('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'lenovo-x1', jenkins_url)
             utils.ghaf_hw_test('.#packages.x86_64-linux.generic-x86_64-debug', 'nuc', jenkins_url)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.microchip-icicle-kit-debug-from-x86_64', 'riscv', jenkins_url)
           }
         }
       }

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -145,6 +145,7 @@ pipeline {
             utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'orin-nx', jenkins_url, testset)
             utils.ghaf_hw_test('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'lenovo-x1', jenkins_url, testset)
             utils.ghaf_hw_test('.#packages.x86_64-linux.generic-x86_64-debug', 'nuc', jenkins_url, testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.microchip-icicle-kit-debug-from-x86_64', 'riscv', jenkins_url, testset)
           }
         }
       }


### PR DESCRIPTION
This PR makes the following changes:
- riscv boot test to main pipeline
- riscv boot, bat, and perf tests to nightly pipeline

Depends on: https://github.com/tiiuae/ghaf-infra/pull/233

(groovy-lint check failure is unrelated to this PR, and will be fixed with: https://github.com/tiiuae/ghaf-jenkins-pipeline/pull/53 now merged, and reabsed this PR on top of the fix)