### PR TITLE
Pin npm-groovy-lint to v14.6.0

### DIFF
--- a/.github/workflows/format-checks.yml
+++ b/.github/workflows/format-checks.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           node-version: '20.13.1'
       - name: Install npm-groovy-lint
-        run: npm install -g npm-groovy-lint
+        run: npm install -g npm-groovy-lint@14.6.0
       - name: Fail if there are any errors
         run: npm-groovy-lint --failon error .


### PR DESCRIPTION
Pin npm-groovy-lint to v14.6.0 to workaround the issue described in https://github.com/nvuillam/npm-groovy-lint/issues/419.