### PR TITLE
Archive HW test results

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -245,6 +245,8 @@ pipeline {
   }
   post {
     always {
+      // Archive Robot-Framework results as artifacts
+      archiveArtifacts allowEmptyArchive: true, artifacts: 'Robot-Framework/test-suites/**/*.html, Robot-Framework/test-suites/**/*.xml'
       // Publish all results under Robot-Framework/test-suites subfolders
       step(
         [$class: 'RobotPublisher',


### PR DESCRIPTION
Archive HW test results in directory hierarchy under 'test-results/'

Depends-on: https://github.com/tiiuae/ghaf-infra/pull/236