### PR TITLE
Use JENKINS_URL in ghaf_hw_test

### DIFF
--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -73,14 +73,13 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            jenkins_url = "https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com"
-            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'orin-agx', jenkins_url)
-            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'orin-agx', jenkins_url)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'orin-nx', jenkins_url)
-            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'orin-nx', jenkins_url)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'lenovo-x1', jenkins_url)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.generic-x86_64-debug', 'nuc', jenkins_url)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.microchip-icicle-kit-debug-from-x86_64', 'riscv', jenkins_url)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'orin-agx')
+            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'orin-agx')
+            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'orin-nx')
+            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'orin-nx')
+            utils.ghaf_hw_test('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'lenovo-x1')
+            utils.ghaf_hw_test('.#packages.x86_64-linux.generic-x86_64-debug', 'nuc')
+            utils.ghaf_hw_test('.#packages.x86_64-linux.microchip-icicle-kit-debug-from-x86_64', 'riscv')
           }
         }
       }

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -137,15 +137,14 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            jenkins_url = "https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com"
             testset = "_boot_bat_perf_"
-            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'orin-agx', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'orin-agx', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'orin-nx', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'orin-nx', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'lenovo-x1', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.generic-x86_64-debug', 'nuc', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.microchip-icicle-kit-debug-from-x86_64', 'riscv', jenkins_url, testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'orin-agx', testset)
+            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'orin-agx', testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'orin-nx', testset)
+            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'orin-nx', testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'lenovo-x1', testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.generic-x86_64-debug', 'nuc', testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.microchip-icicle-kit-debug-from-x86_64', 'riscv', testset)
           }
         }
       }

--- a/ghaf-release-pipeline.groovy
+++ b/ghaf-release-pipeline.groovy
@@ -123,15 +123,14 @@ pipeline {
       steps {
         dir(WORKDIR) {
           script {
-            jenkins_url = "https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com"
             testset = "_boot_bat_perf_"
-            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'orin-agx', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'orin-agx', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'orin-nx', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'orin-nx', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'lenovo-x1', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.generic-x86_64-debug', 'nuc', jenkins_url, testset)
-            utils.ghaf_hw_test('.#packages.x86_64-linux.microchip-icicle-kit-debug-from-x86_64', 'riscv', jenkins_url, testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64', 'orin-agx', testset)
+            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-agx-debug', 'orin-agx', testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64', 'orin-nx', testset)
+            utils.ghaf_hw_test('.#packages.aarch64-linux.nvidia-jetson-orin-nx-debug', 'orin-nx', testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.lenovo-x1-carbon-gen11-debug', 'lenovo-x1', testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.generic-x86_64-debug', 'nuc', testset)
+            utils.ghaf_hw_test('.#packages.x86_64-linux.microchip-icicle-kit-debug-from-x86_64', 'riscv', testset)
           }
         }
       }

--- a/utils.groovy
+++ b/utils.groovy
@@ -174,22 +174,26 @@ def sign_file(String path, String sigfile, String cert="INT-Ghaf-Devenv-Common")
   }
 }
 
-def ghaf_hw_test(String flakeref, String device_config, String jenkins_url, String testset='_boot_') {
+def ghaf_hw_test(String flakeref, String device_config, String testset='_boot_') {
   testagent_nodes = nodesByLabel(label: 'testagent', offline: false)
   if (!testagent_nodes) {
-    println "Warning: Skipping boot test '$flakeref', no test agents online"
+    println "Warning: Skipping HW test '$flakeref', no test agents online"
     unstable("No test agents online")
     return
   }
   if (!env.ARTIFACTS_REMOTE_PATH) {
-    println "Warning: skipping boot_test '$flakeref', ARTIFACTS_REMOTE_PATH not set"
+    println "Warning: skipping HW '$flakeref', ARTIFACTS_REMOTE_PATH not set"
+    return
+  }
+  if (!env.JENKINS_URL) {
+    println "Warning: skipping HW '$flakeref', JENKINS_URL not set"
     return
   }
   // Compose the image URL; testagent will need this URL to download the image
   imgdir = find_img_relpath(flakeref, 'archive')
   remote_path = "artifacts/${env.ARTIFACTS_REMOTE_PATH}"
-  img_url = "${jenkins_url}/${remote_path}/${imgdir}"
-  build_url = "${jenkins_url}/job/${env.JOB_NAME}/${env.BUILD_ID}"
+  img_url = "${env.JENKINS_URL}/${remote_path}/${imgdir}"
+  build_url = "${env.JENKINS_URL}/job/${env.JOB_NAME}/${env.BUILD_ID}"
   build_href = "<a href=\"${build_url}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
   flakeref_trimmed = "${flakeref_trim(flakeref)}"
   // 'short' flakeref: everything after the last occurence of '.' (if any)


### PR DESCRIPTION
Start using `env.JENKINS_URL` in `utils.ghaf_hw_test(...)` as discussed in https://github.com/tiiuae/ghaf-jenkins-pipeline/pull/60#discussion_r1746891796.