### PR TITLE
Misc HW test fixes

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -108,11 +108,16 @@ pipeline {
       steps {
         script {
           env.TEST_CONFIG_DIR = 'Robot-Framework/config'
+          if(!params.getOrDefault('TARGET', null)) {
+            println "Missing TARGET parameter"
+            sh "exit 1"
+          }
+          println "Using TARGET: ${params.TARGET}"
           sh """
             mkdir -p ${TEST_CONFIG_DIR}
             rm -f ${TEST_CONFIG_DIR}/*.json
             ln -sv ${CONF_FILE_PATH} ${TEST_CONFIG_DIR}
-            echo { \\\"Job\\\": \\\"${BUILD_NUMBER}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
+            echo { \\\"Job\\\": \\\"${params.TARGET}\\\" } > ${TEST_CONFIG_DIR}/${BUILD_NUMBER}.json
             ls -la ${TEST_CONFIG_DIR}
           """
           if(!params.containsKey('DESC')) {
@@ -265,13 +270,14 @@ pipeline {
   post {
     always {
       // Archive Robot-Framework results as artifacts
-      archiveArtifacts allowEmptyArchive: true, artifacts: 'Robot-Framework/test-suites/**/*.html, Robot-Framework/test-suites/**/*.xml'
+      archiveArtifacts allowEmptyArchive: true, artifacts: 'Robot-Framework/test-suites/**/*.html, Robot-Framework/test-suites/**/*.xml, Robot-Framework/test-suites/**/*.png'
       // Publish all results under Robot-Framework/test-suites subfolders
       step(
         [$class: 'RobotPublisher',
           archiveDirName: 'robot-plugin',
           outputPath: 'Robot-Framework/test-suites',
           outputFileName: '**/output.xml',
+          otherFiles: '**/*.png',
           disableArchiveOutput: false,
           reportFileName: '**/report.html',
           logFileName: '**/log.html',

--- a/utils.groovy
+++ b/utils.groovy
@@ -210,6 +210,7 @@ def ghaf_hw_test(String flakeref, String device_config, String testset='_boot_')
       string(name: "IMG_URL", value: "$img_url"),
       string(name: "DESC", value: "$description"),
       string(name: "TESTSET", value: "$testset"),
+      string(name: "TARGET", value: "$flakeref_trimmed"),
     ],
     wait: true,
   )


### PR DESCRIPTION
- Robot-Framework generated `.png` images are now collected as artifacts.
- ghaf-hw-test pipeline requires a new parameter `TARGET` which should identify the build target. We pass the trimmed `flakeref` value as a TARGET value from the `utils.groovy:ghaf_hw_test()`.
- Use the TARGET value in `ghaf-hw-test` pipeline as the `Job` key value in the `BUILD_NUMBER.json`. Apparently, this is required in performance test post-analysis tooling.