### PR TITLE
Revert "hw-test: Verify img signature before flashing"

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -8,7 +8,6 @@
 def REPO_URL = 'https://github.com/tiiuae/ci-test-automation/'
 def DEF_LABEL = 'testagent'
 def TMP_IMG_DIR = 'image'
-def TMP_SIG_DIR = 'signature'
 def CONF_FILE_PATH = '/etc/jenkins/test_config.json'
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -161,11 +160,6 @@ pipeline {
           """
           img_relpath = run_cmd("find ${TMP_IMG_DIR} -type f -print -quit | grep .")
           println "Downloaded image to workspace: ${img_relpath}"
-          // Verify signature using the tooling from: https://github.com/tiiuae/ci-yubi
-          sh "wget -nv -P ${TMP_SIG_DIR} ${params.IMG_URL}.sig"
-          sig_relpath = run_cmd("find ${TMP_SIG_DIR} -type f -print -quit | grep .")
-          println "Downloaded signature to workspace: ${sig_relpath}"
-          sh "nix run github:tiiuae/ci-yubi/e2aa4c6#verify -- --path ${img_relpath} --sigfile ${sig_relpath}"
           // Uncompress, keeping only the decompressed image file
           if(img_relpath.endsWith("zst")) {
             sh "zstd -dfv ${img_relpath} && rm ${img_relpath}"


### PR DESCRIPTION
This reverts commit f80a154e45239d9974e4f3c1575d24521e29b593.

Signature verification service is not reliable currently, causing occasional failures such as:

```
08:16:43  + nix run github:tiiuae/ci-yubi/e2aa4c6#verify -- --path image/nixos.img --sigfile signature/nixos.img.sig
08:16:52  Error: 503, Response: The service is unavailable.
```

Which then cascade a build failure.

This PR reverts https://github.com/tiiuae/ghaf-jenkins-pipeline/pull/68 - let's re-enable the verification once it works reliably.