### PR TITLE
Mark pre-merge pipeline as failed if any target fails

### DIFF
--- a/ghaf-pre-merge-pipeline.groovy
+++ b/ghaf-pre-merge-pipeline.groovy
@@ -153,12 +153,18 @@ pipeline {
 
               target_jobs[target] = {
                 stage("${target}") {
-                  catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+                  try {
                     if (drvPath) {
-                      sh "nix build -L ${drvPath}\\^*"
+                      sh "nix build --no-link -L ${drvPath}\\^*"
                     } else {
                       error("Target \"${target}\" was not found in ${flakeAttr}")
                     }
+                  } catch (InterruptedException e) {
+                    throw e
+                  } catch (Exception e) {
+                    unstable("FAILED: ${target}")
+                    currentBuild.result = "FAILURE"
+                    println "Error: ${e.toString()}"
                   }
                 }
               }


### PR DESCRIPTION
Reusing the error handling logic from `utils.groovy`. The reason we can't just use the `nix_build` from utils is that it's not equipped to deal with raw derivation paths, and expects a flake reference. There is also lot of unnecessary steps not suitable for parallel building, such as signing and artifact archiving.