### PR TITLE
Disable concurrent builds in all pipelines

### DIFF
--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -48,6 +48,7 @@ pipeline {
      pollSCM('* * * * *')
   }
   options {
+    disableConcurrentBuilds()
     timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }

--- a/ghaf-parallel-pipeline.groovy
+++ b/ghaf-parallel-pipeline.groovy
@@ -49,6 +49,7 @@ pipeline {
     pollSCM '0 23 * * *'
   }
   options {
+    disableConcurrentBuilds()
     timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }

--- a/ghaf-pre-merge-pipeline.groovy
+++ b/ghaf-pre-merge-pipeline.groovy
@@ -63,6 +63,7 @@ properties([
 pipeline {
   agent { label 'built-in' }
   options {
+    disableConcurrentBuilds()
     timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }


### PR DESCRIPTION
Workaround for build queue spam. Doesn't impact parallel builds within a pipeline stage.