### PR TITLE
Only evaluate what is needed to build

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -304,6 +304,29 @@ def ghaf_parallel_hw_test(String flakeref, String device_config, String testset=
   archive_artifacts("ghaf-parallel-hw-test", flakeref_trimmed)
 }
 
+def nix_eval_jobs(List<Map> targets) {
+  // transform target names into valid nix arrays to be plugged into the expression below
+  def x86_targets = "\"${targets.findAll { it.system == "x86_64-linux" }.target.join('" "')}\""
+  def aarch64_targets = "\"${targets.findAll { it.system == "aarch64-linux" }.target.join('" "')}\""
+
+  // nix-eval-jobs is used to evaluate the targets in parallel and compute derivation paths.
+  // nix expression is used to create an attset on the fly which is a subset of #packages, 
+  // but only includes the targets we want to build, to save time
+  sh """
+    nix-eval-jobs --gc-roots-dir gcroots --force-recurse --expr ' \
+      let \
+        flake = builtins.getFlake ("git+file://" + toString ./.); \
+        lib = (import flake.inputs.nixpkgs { }).lib; \
+      in { \
+        x86_64-linux = lib.getAttrs [ ${x86_targets} ] flake.packages.x86_64-linux; \
+        aarch64-linux = lib.getAttrs [ ${aarch64_targets} ] flake.packages.aarch64-linux; \
+      }' > jobs.json
+  """
+
+  // target's name and derivation path are read from jobs.json and written into into jobs.txt
+  sh "jq -r '.attr + \" \" + .drvPath' < jobs.json > jobs.txt"
+}
+
 return this
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The current implementation of the parallel evaluation stage evaluates the entire `#hydraJobs` attribute of ghaf, even though we don't build half of the packages it contains. This is wasteful.

`nix-eval-jobs` can take arbitrary nix expression as input, so I'm creating a new attribute set on the fly, which is a subset of ghaf `#packages`, only containing the targets we need, and evaluating that instead.

From my testing, this shaves our evaluation time in main pipeline from 7-8 minutes to just under 3 minutes (with the current set of targets)

As for the move to `#packages`, some of the newer targets are not available in `#hydraJobs`, as it's being phased out and not updated anymore. Nightly pipeline for example currently could not be built in parallel for this reason. Ghaf `#packages` set is very large so without this optimisation it would have taken ages to evaluate.
