### PR TITLE
Add gui test suite to nightly pipeline

### DIFF
--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -208,7 +208,7 @@ pipeline {
               stage("Test ${it.target} (${it.system})") {
                 script {
                   def targetAttr = "${it.system}.${it.target}"
-                  utils.ghaf_hw_test(targetAttr, it.hwtest_device, '_boot_bat_perf_')
+                  utils.ghaf_hw_test(targetAttr, it.hwtest_device, '_boot_gui_bat_perf_')
                 }
               }
             }


### PR DESCRIPTION
We should get also automated gui tests running in the pipeline to get more information of the stability and possible problems of the gui suite. 