### PR TITLE
Fix provenance signature path

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -379,7 +379,7 @@ def create_parallel_stages(List<Map> targets, String testset='_boot_bat_perf_', 
                 mkdir -p ${scsdir}
                 provenance ${it.drvPath} --recursive --out ${outpath}
               """
-              sign_file(outpath, "sig/${outpath}.sig", "INT-Ghaf-Devenv-Provenance")
+              sign_file(outpath, "${outpath}.sig", "INT-Ghaf-Devenv-Provenance")
             }
           }
         }


### PR DESCRIPTION
Puts provenance signature into same path as the provenance file itself.