### PR TITLE
Add stage definition for GUI test

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -234,6 +234,14 @@ pipeline {
         }
       }
     }
+    stage('GUI test') {
+      when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_gui_')} }
+      steps {
+        script {
+          ghaf_robot_test('gui')
+        }
+      }
+    }
     stage('Perf test') {
       when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_perf_')} }
       steps {


### PR DESCRIPTION
GUI was already added to Hardware tests stage definition but the definition for GUI test stage was missing.

Tested this in
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-hw-test/103/robot/report/**/report.html
(perf test stage was temporarily removed to speed up testing)

'Start and close chrome via GUI on LenovoX1' fails, it is a known issue in closing chrome window after first launch.