### PR TITLE
Launch gui test suite only for lenovo-x1

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -235,7 +235,7 @@ pipeline {
       }
     }
     stage('GUI test') {
-      when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_gui_')} }
+      when { expression { env.BOOT_PASSED == 'true' && params.DEVICE_CONFIG_NAME == "lenovo-x1" && env.TESTSET.contains('_gui_')} }
       steps {
         script {
           ghaf_robot_test('gui')

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -208,7 +208,7 @@ pipeline {
               stage("Test ${it.target} (${it.system})") {
                 script {
                   def targetAttr = "${it.system}.${it.target}"
-                  utils.ghaf_hw_test(targetAttr, it.hwtest_device, '_boot_gui_bat_perf_video_logging_')
+                  utils.ghaf_hw_test(targetAttr, it.hwtest_device, '_boot_gui_bat_perf_')
                 }
               }
             }


### PR DESCRIPTION
Fixes the problem that running gui test suite is attempted on every target (causing HW tests to fail) although ci-test-automation has tag for only lenovo-x1 in gui tests? GUI test suite is meant to be run only on x1 for now.

Removed also video and logging tags from nightly-pipeline hwtests because those test suites are soon going to merged to bat suite. 

Tested nightly-pipeline on dev setup (build 31), seems to work. (Boot test failed for nuc and riscv.)

Lenovo-X1:
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-hw-test/129/
![image](https://github.com/user-attachments/assets/05950ffa-975f-4b69-ad23-d174308d7bd6)

Orin-AGX:
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-hw-test/130/
![image](https://github.com/user-attachments/assets/e8c18abc-bc65-426c-8692-f96aa556f7b3)

Orin-NX:
https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-hw-test/131/
![image](https://github.com/user-attachments/assets/b62c5c07-60ae-497a-9585-0363adc00c4b)
