### PR TITLE
Remove aarch64-linux doc targets

### DIFF
--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -24,12 +24,6 @@ def target_jobs = [:]
 
 def targets = [
   [ target: "doc",
-    system: "aarch64-linux",
-    archive: false,
-    scs: false,
-    hwtest_device: null,
-  ],
-  [ target: "doc",
     system: "x86_64-linux",
     archive: false,
     scs: false,

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -29,12 +29,6 @@ def targets = [
     scs: false,
     hwtest_device: null,
   ],
-  [ target: "doc",
-    system: "aarch64-linux",
-    archive: false,
-    scs: false,
-    hwtest_device: null,
-  ],
 
   // lenovo x1
   [ target: "lenovo-x1-carbon-gen11-debug",

--- a/ghaf-pre-merge-pipeline.groovy
+++ b/ghaf-pre-merge-pipeline.groovy
@@ -52,12 +52,6 @@ def target_jobs = [:]
 
 def targets = [
   [ target: "doc",
-    system: "aarch64-linux",
-    archive: false,
-    scs: false,
-    hwtest_device: null,
-  ],
-  [ target: "doc",
     system: "x86_64-linux",
     archive: false,
     scs: false,


### PR DESCRIPTION
Ghaf flake output `aarch64-linux.doc` has been removed: https://github.com/tiiuae/ghaf/pull/972