### PR TITLE
Run pipelines in parallel

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -74,7 +74,6 @@ def ghaf_robot_test(String testname='boot') {
 
 pipeline {
   agent { label "${params.getOrDefault('LABEL', DEF_LABEL)}" }
-  options { timestamps () }
   stages {
     stage('Checkout') {
       steps {

--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -100,9 +100,11 @@ pipeline {
     stage('Evaluate') {
       steps {
         dir(WORKDIR) {
-          script {
-            utils.nix_eval_jobs(targets)
-            target_jobs = utils.create_parallel_stages(targets, testset='_boot_bat_', failedTargets=failedTargets, failedHWTests=failedHWTests)
+          lock('evaluator') {
+            script {
+              utils.nix_eval_jobs(targets)
+              target_jobs = utils.create_parallel_stages(targets, testset='_boot_bat_', failedTargets=failedTargets, failedHWTests=failedHWTests)
+            }
           }
         }
       }

--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -75,7 +75,6 @@ pipeline {
      pollSCM('* * * * *')
   }
   options {
-    timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {

--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -75,7 +75,6 @@ pipeline {
      pollSCM('* * * * *')
   }
   options {
-    disableConcurrentBuilds()
     timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -140,7 +140,6 @@ pipeline {
   }
 
   options {
-    disableConcurrentBuilds()
     timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }
@@ -168,13 +167,15 @@ pipeline {
     stage('Evaluate') {
       steps {
         dir(WORKDIR) {
-          script {
-            utils.nix_eval_jobs(targets)
-            // remove when hydrajobs is retired from ghaf
-            utils.nix_eval_hydrajobs(hydrajobs_targets)
-            targets = targets + hydrajobs_targets
+          lock('evaluator') {
+            script {
+              utils.nix_eval_jobs(targets)
+              // remove when hydrajobs is retired from ghaf
+              utils.nix_eval_hydrajobs(hydrajobs_targets)
+              targets = targets + hydrajobs_targets
 
-            target_jobs = utils.create_parallel_stages(targets, testset=null)
+              target_jobs = utils.create_parallel_stages(targets, testset=null)
+            }
           }
         }
       }

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -140,7 +140,6 @@ pipeline {
   }
 
   options {
-    timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }
 

--- a/ghaf-pre-merge-pipeline.groovy
+++ b/ghaf-pre-merge-pipeline.groovy
@@ -100,7 +100,6 @@ def targets = [
 pipeline {
   agent { label 'built-in' }
   options {
-    disableConcurrentBuilds()
     timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }
@@ -178,9 +177,11 @@ pipeline {
     stage('Evaluate') {
       steps {
         dir(WORKDIR) {
-          script {
-            utils.nix_eval_jobs(targets)
-            target_jobs = utils.create_parallel_stages(targets, testset='_boot_pre-merge_')
+          lock('evaluator') {
+            script {
+              utils.nix_eval_jobs(targets)
+              target_jobs = utils.create_parallel_stages(targets, testset='_boot_pre-merge_')
+            }
           }
         }
       }

--- a/ghaf-pre-merge-pipeline.groovy
+++ b/ghaf-pre-merge-pipeline.groovy
@@ -100,7 +100,6 @@ def targets = [
 pipeline {
   agent { label 'built-in' }
   options {
-    timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   stages {

--- a/ghaf-release-pipeline.groovy
+++ b/ghaf-release-pipeline.groovy
@@ -86,7 +86,6 @@ def targets = [
 pipeline {
   agent { label 'built-in' }
   options {
-    disableConcurrentBuilds()
     timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }
@@ -116,9 +115,11 @@ pipeline {
     stage('Evaluate') {
       steps {
         dir(WORKDIR) {
-          script {
-            utils.nix_eval_jobs(targets)
-            target_jobs = utils.create_parallel_stages(targets, testset=null)
+          lock('evaluator') {
+            script {
+              utils.nix_eval_jobs(targets)
+              target_jobs = utils.create_parallel_stages(targets, testset=null)
+            }
           }
         }
       }

--- a/tests/x-ghaf-hw-test.groovy
+++ b/tests/x-ghaf-hw-test.groovy
@@ -139,7 +139,6 @@ def ghaf_robot_test(String test_tags) {
 
 pipeline {
   agent { label parse_image_url_and_set_device() }
-  options { timestamps () }
   stages {
     stage('Refresh') {
       when { expression { params.getOrDefault('REFRESH', false) } }

--- a/tests/x-ghaf-pre-merge.groovy
+++ b/tests/x-ghaf-pre-merge.groovy
@@ -87,7 +87,6 @@ pipeline {
   agent { label 'built-in' }
   options {
     disableConcurrentBuilds()
-    timestamps ()
     buildDiscarder(logRotator(numToKeepStr: '100'))
   }
   environment {


### PR DESCRIPTION
ghaf-infra PR required: https://github.com/tiiuae/ghaf-infra/pull/356

- Uses a lock on the evaluator to prevent collisions.
- Timestamps option removed as it's now enabled by default.
- Concurrent builds are now enabled.