### PR TITLE
Use Github webhook to trigger main and FMO pipeline

### DIFF
--- a/fmo-os-main-pipeline.groovy
+++ b/fmo-os-main-pipeline.groovy
@@ -59,7 +59,7 @@ pipeline {
       defaultValue: DEFAULT_REF
   }
   triggers {
-    pollSCM '* * * * *'
+    githubPush()
   }
   options {
     disableConcurrentBuilds()

--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -72,7 +72,7 @@ def targets = [
 pipeline {
   agent { label 'built-in' }
   triggers {
-     pollSCM('* * * * *')
+    githubPush()
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '100'))


### PR DESCRIPTION
Pipeline is built when there is a change in SCM. Requires json webhook to be configured in the target repository on push event, with the payload URL set to `https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/github-webhook/` (already done for ghaf)