### PR TITLE
x-ghaf-hw-test.groovy:  Jenkins result reporting fix

### DIFF
--- a/tests/x-ghaf-hw-test.groovy
+++ b/tests/x-ghaf-hw-test.groovy
@@ -18,7 +18,7 @@ properties([
     string(name: 'TEST_TAGS', defaultValue: '', description: 'Target test tags device need to match with given image URL!(combination of device and tag(s) or just a tag e.g.: bootANDorin-nx, SP-T65, SP-T45ORSP-T60 etc..)'),
     booleanParam(name: 'REFRESH', defaultValue: false, description: 'Read the Jenkins pipeline file and exit, setting the build status to failure.'),
     booleanParam(name: 'FLASH_AND_BOOT', defaultValue: true, description: 'If this is set then image will be downloaded and drive flashed.'),
-    booleanParam(name: 'USE_RELAY', defaultValue: false, description: 'If this is set then relay board will be used to cut power from target device when FLASH_AND_BOOT is enabled')
+    booleanParam(name: 'USE_RELAY', defaultValue: true, description: 'If this is set then relay board will be used to cut power from target device when FLASH_AND_BOOT is enabled')
   ])
 ])
 

--- a/tests/x-ghaf-hw-test.groovy
+++ b/tests/x-ghaf-hw-test.groovy
@@ -283,17 +283,11 @@ pipeline {
       }
       script {
         if (env.BOOT_PASSED != null) {
-          // Archive Robot-Framework results as artifacts
-          archive = "Robot-Framework/test-suites/**/*.html"
-          archive = "${archive}, Robot-Framework/test-suites/**/*.xml"
-          archive = "${archive}, Robot-Framework/test-suites/**/*.png"
-          archive = "${archive}, Robot-Framework/test-suites/**/*.txt"
-          archiveArtifacts allowEmptyArchive: true, artifacts: archive
-          // Publish all results under Robot-Framework/test-suites subfolders
+          // Publish all results under Robot-Framework/test-suites/$test_tags subfolders
           step(
             [$class: 'RobotPublisher',
               archiveDirName: 'robot-plugin',
-              outputPath: 'Robot-Framework/test-suites',
+              outputPath: 'Robot-Framework/test-suites/$test_tags',
               outputFileName: '**/output.xml',
               otherFiles: '**/*.png',
               disableArchiveOutput: false,


### PR DESCRIPTION
Fixing the failures in result post actions. 
x-ghaf-hw-test.groovy
- Removed the 'Archive Robot-Framework results as artifacts' -part, added '$test_tags' to RobotFramework's output path.
- As per request set also 'USE_RELAY's default valu to true

Now the Jenkins pipeline should produce 'green' if tests do pass.

Test result/trial: [dev -pipeline](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test-mikkos/110/)