### PR TITLE
Added '*.txt' as possible result file.

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -39,7 +39,7 @@ def ghaf_robot_test(String testname='boot') {
     env.INCLUDE_TEST_TAGS = "${testname}AND${env.DEVICE_TAG}"
   }
   dir("Robot-Framework/test-suites") {
-  sh 'rm -f *.png output.xml report.html log.html'
+  sh 'rm -f *.txt *.png output.xml report.html log.html'
   // On failure, continue the pipeline execution
   try {
   // Pass variables as environment variables to shell.
@@ -68,7 +68,7 @@ def ghaf_robot_test(String testname='boot') {
     // Move the test output (if any) to a subdirectory
     sh """
       rm -fr $testname; mkdir -p $testname
-      mv -f *.png output.xml report.html log.html $testname/ || true
+      mv -f *.txt *.png output.xml report.html log.html $testname/ || true
     """
     }
   }
@@ -294,6 +294,7 @@ pipeline {
           outputPath: 'Robot-Framework/test-suites',
           outputFileName: '**/output.xml',
           otherFiles: '**/*.png',
+          otherFiles: '**/*.txt',
           disableArchiveOutput: false,
           reportFileName: '**/report.html',
           logFileName: '**/log.html',

--- a/tests/x-ghaf-hw-test.groovy
+++ b/tests/x-ghaf-hw-test.groovy
@@ -107,7 +107,7 @@ def ghaf_robot_test(String test_tags) {
     }
   }
   dir("Robot-Framework/test-suites") {
-    sh 'rm -f *.png output.xml report.html log.html'
+    sh 'rm -f *.txt *.png output.xml report.html log.html'
     // On failure, continue the pipeline execution
     env.COMMIT_HASH = (params.IMG_URL =~ /commit_([a-f0-9]{40})/)[0][1]
     try {
@@ -132,7 +132,7 @@ def ghaf_robot_test(String test_tags) {
       // Move the test output (if any) to a subdirectory
       sh """
         rm -fr $test_tags; mkdir -p $test_tags
-        mv -f *.png output.xml report.html log.html $test_tags/ || true
+        mv -f *.txt *.png output.xml report.html log.html $test_tags/ || true
       """
     }
   }
@@ -293,6 +293,7 @@ pipeline {
               outputPath: 'Robot-Framework/test-suites/$test_tags',
               outputFileName: '**/output.xml',
               otherFiles: '**/*.png',
+              otherFiles: '**/*.txt',
               disableArchiveOutput: false,
               reportFileName: '**/report.html',
               logFileName: '**/log.html',


### PR DESCRIPTION
Added '.txt' -file into robot output files and those should also stored.

Tried the code in 'prod'-env x-ghaf-hw-test: [96](https://ghaf-jenkins-controller-prod.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/96/robot/report/)

Some more testing with DEV setup where 'Ghaf HW test'  got script from this branch.
-  Trigger (Ghaf main pipeline) [105 ](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-main-pipeline/105/)
- HW tests [646-652](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-hw-test/651/robot/report/bat/) - the jrnl.txt is inluded to the bat-directory with other test results. (if bat- tests got executed)