### PR TITLE
Wipe workspace before checkout

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -83,7 +83,7 @@ pipeline {
       steps {
         checkout scmGit(
           branches: [[name: 'main']],
-          extensions: [cleanBeforeCheckout()],
+          extensions: [[$class: 'WipeWorkspace']],
           userRemoteConfigs: [[url: REPO_URL]]
         )
       }

--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -96,7 +96,7 @@ pipeline {
         dir(WORKDIR) {
           checkout scmGit(
             branches: [[name: 'main']],
-            extensions: [cleanBeforeCheckout()],
+            extensions: [[$class: 'WipeWorkspace']],
             userRemoteConfigs: [[url: REPO_URL]]
           )
           script {

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -165,7 +165,7 @@ pipeline {
         dir(WORKDIR) {
           checkout scmGit(
             branches: [[name: 'main']],
-            extensions: [cleanBeforeCheckout()],
+            extensions: [[$class: 'WipeWorkspace']],
             userRemoteConfigs: [[url: REPO_URL]]
           )
           script {

--- a/ghaf-perftest-pipeline.groovy
+++ b/ghaf-perftest-pipeline.groovy
@@ -90,7 +90,7 @@ pipeline {
         dir(WORKDIR) {
           checkout scmGit(
             branches: [[name: env.GITREF]],
-            extensions: [cleanBeforeCheckout()],
+            extensions: [[$class: 'WipeWorkspace']],
             userRemoteConfigs: [[url: REPO_URL]]
           )
           script {

--- a/ghaf-pre-merge-pipeline.groovy
+++ b/ghaf-pre-merge-pipeline.groovy
@@ -151,7 +151,7 @@ pipeline {
             ]],
             branches: [[name: 'pr_origin/pull/${GITHUB_PR_NUMBER}/merge']],
             extensions: [
-              cleanBeforeCheckout(),
+              [$class: 'WipeWorkspace'],
               // We use the 'changelogToBranch' extension to correctly
               // show the PR changed commits in Jenkins changes.
               // References:

--- a/ghaf-release-pipeline.groovy
+++ b/ghaf-release-pipeline.groovy
@@ -100,7 +100,7 @@ pipeline {
         dir(WORKDIR) {
           checkout scmGit(
             branches: [[name: env.GITREF]],
-            extensions: [cleanBeforeCheckout()],
+            extensions: [[$class: 'WipeWorkspace']],
             userRemoteConfigs: [[url: REPO_URL]]
           )
           script {

--- a/tests/x-ghaf-pre-merge.groovy
+++ b/tests/x-ghaf-pre-merge.groovy
@@ -119,7 +119,7 @@ pipeline {
             ]],
             branches: [[name: 'pr_origin/pull/${GITHUB_PR_NUMBER}/merge']],
             extensions: [
-              cleanBeforeCheckout(),
+              [$class: 'WipeWorkspace'],
             ],
           )
           script {

--- a/utils.groovy
+++ b/utils.groovy
@@ -340,12 +340,12 @@ def create_parallel_stages(List<Map> targets, String testset='_boot_bat_perf_', 
         } catch (InterruptedException e) {
           throw e
         } catch (Exception e) {
-          unstable("FAILED: ${displayName}")
-          currentBuild.result = "FAILURE"
           if (failedTargets != null) {
             failedTargets.add(targetAttr)
           }
           println "Error: ${e.toString()}"
+          // Stop running remaining steps if build failed
+          throw e
         }
       }
 


### PR DESCRIPTION
For some reason, `cleanBeforeCheckout()` doesn't always clean the workspace. The changes in this PR replace the `cleanBeforeCheckout()`  with `[$class: 'WipeWorkspace']` which, in testing, always cleans the workspace before execution.

Additionally, this change makes the build step throw in case of failure, in order to stop running remaining steps on build failure. Earlier, before changes from https://github.com/tiiuae/ghaf-jenkins-pipeline/pull/99, builds were executed in sequence and for that reason, the builds were required to continue on failure. With the parallel thing, we want the remaining build steps to **not** run if a nix build fails.

The changes from this PR fix an issue in the pre-merge-pipeline in which a previous build artifacts could have been used in archive and HW testing steps, even if the current build failed.