### PR TITLE
Refactor 'x-ghaf-hw-test.groovy'

### DIFF
--- a/tests/x-ghaf-hw-test.groovy
+++ b/tests/x-ghaf-hw-test.groovy
@@ -286,17 +286,20 @@ pipeline {
       }
       script {
         if (env.BOOT_PASSED != null) {
-          // Publish all results under Robot-Framework/test-suites/$test_tags subfolders
+          // Archive Robot-Framework results as artifacts
+          archive = "Robot-Framework/test-suites/$test_tags/**/*.html, Robot-Framework/test-suites/$test_tags/**/*.xml, Robot-Framework/test-suites/$test_tags/**/*.png, Robot-Framework/test-suites/$test_tags/**/*.txt"
+          archiveArtifacts allowEmptyArchive: true, artifacts: archive
+          // Publish all results under Robot-Framework/test-suites/$test_tags/ subfolders
           step(
             [$class: 'RobotPublisher',
               archiveDirName: 'robot-plugin',
               outputPath: 'Robot-Framework/test-suites/$test_tags',
-              outputFileName: '**/output.xml',
-              otherFiles: '**/*.png',
-              otherFiles: '**/*.txt',
+              outputFileName: '**/**/output.xml',
+              otherFiles: '**/**/*.png',
+              otherFiles: '**/**/*.txt',
               disableArchiveOutput: false,
-              reportFileName: '**/report.html',
-              logFileName: '**/log.html',
+              reportFileName: '**/**/report.html',
+              logFileName: '**/**/log.html',
               passThreshold: 0,
               unstableThreshold: 0,
               onlyCritical: true,


### PR DESCRIPTION
Test having pictures as output did loose those when artifact handling.
Fixed now with this PR

Test Result: [x-ghaf-hw-test 902](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/tests/job/x-ghaf-hw-test/902/)