### PR TITLE
Enable parallel HW tests for release pipeline

### DIFF
--- a/ghaf-release-pipeline.groovy
+++ b/ghaf-release-pipeline.groovy
@@ -113,7 +113,7 @@ pipeline {
           lock('evaluator') {
             script {
               utils.nix_eval_jobs(targets)
-              target_jobs = utils.create_parallel_stages(targets, testset=null)
+              target_jobs = utils.create_parallel_stages(targets, testset='_relayboot_bat_')
             }
           }
         }

--- a/ghaf-release-pipeline.groovy
+++ b/ghaf-release-pipeline.groovy
@@ -127,24 +127,7 @@ pipeline {
         }
       }
     }
-
-    stage('Hardware tests') {
-      steps {
-        script {
-          targets.each {
-            if (it.hwtest_device != null) {
-              stage("Test ${it.target} (${it.system})") {
-                script {
-                  def targetAttr = "${it.system}.${it.target}"
-                  utils.ghaf_hw_test(targetAttr, it.hwtest_device, '_relayboot_bat_')
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+ }
   post {
     always {
       script {


### PR DESCRIPTION
Enable parallel hw tests for release pipeline.
Clean up the pipeline.
Deployed and tested in uae.