### PR TITLE
Add Lenovo-X1 Cosmic to nightly pipeline

### DIFF
--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -58,6 +58,12 @@ def targets = [
     scs: true,
     hwtest_device: null,
   ],
+  [ target: "lenovo-x1-gen11-cosmic-debug",
+    system: "x86_64-linux",
+    archive: true,
+    scs: false,
+    hwtest_device: "lenovo-x1",
+  ],
 
   // Dell Latitude rugged laptops
   [ target: "dell-latitude-7230-debug",


### PR DESCRIPTION
Ghaf is currently using Labwc as a compositor. There is a plan to switch at least some x86 targets to Cosmic soon.

In preparation for that adds Lenovo-X1 Cosmic image to the nightly pipeline to be built and tested regularly. This target can be removed once the normal `lenovo-x1-carbon-gen11-debug` image starts using Cosmic.

[Testrun](https://ghaf-jenkins-controller-dev.northeurope.cloudapp.azure.com/job/ghaf-nightly-pipeline/80/) - All Lenovo-X1 tests for both Labwc and Cosmic passed. There are some hardware issues in the dev setup so not all tests pass for other targets.