### PR TITLE
Delete old 'sig' directories from workdir

### DIFF
--- a/ghaf-main-pipeline.groovy
+++ b/ghaf-main-pipeline.groovy
@@ -101,7 +101,10 @@ pipeline {
   stages {
     stage('Checkout') {
       steps {
-        script { utils = load "utils.groovy" }
+        script {
+	  sh(script: 'rm -Rf sig')
+	  utils = load "utils.groovy"
+	}
         dir(WORKDIR) {
           checkout scmGit(
             branches: [[name: 'main']],

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -183,7 +183,10 @@ pipeline {
 
     stage('Checkout') {
       steps {
-        script { utils = load "utils.groovy" }
+        script {
+	  sh(script: 'rm -Rf sig')
+	  utils = load "utils.groovy"
+	}
         dir(WORKDIR) {
           checkout scmGit(
             branches: [[name: 'main']],

--- a/ghaf-perftest-pipeline.groovy
+++ b/ghaf-perftest-pipeline.groovy
@@ -87,7 +87,10 @@ pipeline {
   stages {
     stage('Checkout') {
       steps {
-        script { utils = load "utils.groovy" }
+        script {
+	  sh(script: 'rm -Rf sig')
+	  utils = load "utils.groovy"
+	}
         dir(WORKDIR) {
           checkout scmGit(
             branches: [[name: env.GITREF]],

--- a/ghaf-pre-merge-pipeline.groovy
+++ b/ghaf-pre-merge-pipeline.groovy
@@ -125,7 +125,10 @@ pipeline {
     }
     stage('Checkout') {
       steps {
-        script { utils = load "utils.groovy" }
+        script {
+	  sh(script: 'rm -Rf sig')
+	  utils = load "utils.groovy"
+	}
         dir(WORKDIR) {
           // References:
           // https://www.jenkins.io/doc/pipeline/steps/params/scmgit/#scmgit


### PR DESCRIPTION
Previously we cleaned only ghaf git repository clone. 'sig' lives outside that clone.