### PR TITLE
Add turn off and on functionality for Dev pipelines

### DIFF
--- a/turn-off-test-devices.groovy
+++ b/turn-off-test-devices.groovy
@@ -1,0 +1,105 @@
+#!/usr/bin/env groovy
+
+// SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+// SPDX-License-Identifier: Apache-2.0
+
+////////////////////////////////////////////////////////////////////////////////
+
+def REPO_URL = 'https://github.com/tiiuae/ci-test-automation/'
+def WORKDIR = 'ghaf'
+
+////////////////////////////////////////////////////////////////////////////////
+
+def hwtest_devices = [
+  "lenovo-x1",
+//   "dell-7330",  // we can't reliably find out if laptop is on or off, so if it was off already we will turn in on
+  "orin-agx",
+  "orin-agx-64",
+  "orin-nx"
+]
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+def ghaf_robot_test(String hwtest_device) {
+  def testagent_nodes = nodesByLabel(label: "$hwtest_device", offline: false)
+  if (!testagent_nodes) {
+    println "Warning: Skipping HW test '$flakeref', no test agents online"
+    unstable("No test agents online")
+    return
+  }
+
+  def job = build(
+      job: "tests/x-ghaf-hw-test",
+      propagate: false,
+      parameters: [
+        string(name: "REPO_URL", value: 'https://github.com/tiiuae/ci-test-automation.git'),
+        string(name: "IMG_URL", value: ""),
+        string(name: "DEVICE_TAG", value: "$hwtest_device"),
+        string(name: "BRANCH", value: "main"),
+        string(name: "TEST_TAGS", value: ""),
+        booleanParam(name: "REFRESH", value: false),
+        booleanParam(name: "FLASH_AND_BOOT", value: false),
+        booleanParam(name: "BOOT", value: false),
+        booleanParam(name: "TURN_OFF", value: true),
+        booleanParam(name: "USE_RELAY", value: true),
+      ],
+      wait: true,
+  )
+
+  // If the test job failed, mark the current step unstable and set
+  // the final build result failed, but continue the pipeline execution.
+  if (job.result != "SUCCESS") {
+    unstable("FAILED: $hwtest_device")
+    currentBuild.result = "FAILURE"
+  }
+  return null
+}
+
+pipeline {
+  agent { label 'built-in' }
+  triggers {
+    cron('0 19 * * *')
+  }
+  options {
+    disableConcurrentBuilds()
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr: '100'))
+  }
+  environment {
+    // https://stackoverflow.com/questions/46680573
+    GITREF = params.getOrDefault('GITREF', 'main')
+  }
+  stages {
+    stage('Checkout') {
+      steps {
+        dir(WORKDIR) {
+          checkout scmGit(
+            branches: [[name: env.GITREF]],
+            extensions: [[$class: 'WipeWorkspace']],
+            userRemoteConfigs: [[url: REPO_URL]]
+          )
+          script {
+            env.TARGET_REPO = sh(script: 'git remote get-url origin', returnStdout: true).trim()
+            env.TARGET_COMMIT = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
+            env.ARTIFACTS_REMOTE_PATH = "${env.JOB_NAME}/build_${env.BUILD_ID}"
+          }
+        }
+      }
+    }
+
+    stage('Turn off devices') {
+      steps {
+        script {
+          hwtest_devices.each { device ->
+            stage("Turn off ${device}") {
+              script {
+                ghaf_robot_test(device)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
A new pipeline "turn-off-test-devices" has been created for the Dev setup. It automatically turns off all devices at 10 PM  for safety and robustness reasons. (Unlike production devices, which are automatically shut down after test runs, tests on Dev devices are mostly executed manually and are not always followed by a shutdown.)
Instead of using the ghaf-hw-test pipeline (which includes a build step we don't need here), we use the more lightweight x-ghaf-hw-test.

"x-ghaf-hw-test" was refactored to be more flexible:
- Added a TURN_OFF flag that can be used either with test tags (to turn off the device after the test) or independently.
- Added a BOOT flag that allows booting the device without flashing.
- Added a DEVICE_TAG parameter which can be given instead of IMG_URL, in cases where flashing is not needed.

For now we exclude Dell7330 from the "turn off list" because we can't reliably find out if laptop is on or off (for example it can be on but stuck and not responding the ping), so if it was off already we will turn in on. We will include it to the list later when we find the proper solution.