### PR TITLE
Stop running vulnxscan

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -412,16 +412,6 @@ def create_parallel_stages(List<Map> targets, String testset='_boot_bat_perf_', 
             }
           }
         }
-
-        stage("Vulnxscan ${displayName}") {
-          catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-            sh """
-              mkdir -p ${scsdir}
-              vulnxscan ${it.drvPath} --out vulns.csv
-              csvcut vulns.csv --not-columns sortcol | csvlook -I >${scsdir}/vulns.txt
-            """
-          }
-        }
       }
 
       if (it.archive) {


### PR DESCRIPTION
Vulnxscan often fails for one or more targets because there are issues with the `grype` tool.

In addition ghafscan provides more informative vulnerability scan results in https://github.com/tiiuae/ghafscan/tree/main/reports/main

Ghafscan results are being actively followed but vulnxscan results are not.