### PR TITLE
Add regression testset

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -250,6 +250,14 @@ pipeline {
         }
       }
     }
+    stage('Regression test') {
+      when { expression { env.BOOT_PASSED == 'true' && env.TESTSET.contains('_regression_')} }
+      steps {
+        script {
+          ghaf_robot_test('regression')
+        }
+      }
+    }
     stage('GUI test') {
       when { expression { env.BOOT_PASSED == 'true' && params.DEVICE_CONFIG_NAME == "lenovo-x1" && env.TESTSET.contains('_gui_')} }
       steps {

--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -213,7 +213,7 @@ pipeline {
               // utils.nix_eval_hydrajobs(hydrajobs_targets)
               //targets = targets + hydrajobs_targets
 
-              target_jobs = utils.create_parallel_stages(targets, testset='_relayboot_gui_bat_')
+              target_jobs = utils.create_parallel_stages(targets, testset='_relayboot_gui_regression_')
             }
           }
         }


### PR DESCRIPTION
Now there are 2 testsets: BAT and Regression. Regression contains more and longer tests and will be executed only in night. In main pipeline we will continue run BAT tests and will keep reasonable time of testrun.
Was tested on Dev.