### PR TITLE
Use provenance policy checker in ghaf-hw-test

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -9,7 +9,9 @@ def REPO_URL = 'https://github.com/tiiuae/ci-test-automation/'
 def DEF_LABEL = 'testagent'
 def TMP_IMG_DIR = 'image'
 def TMP_SIG_DIR = 'signature'
+def TMP_PROVENANCE_DIR = 'provenance'
 def CONF_FILE_PATH = '/etc/jenkins/test_config.json'
+def TRUST_POLICY_PATH = '/etc/jenkins/provenance-trust-policy.json'
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -111,6 +113,39 @@ pipeline {
           }
           env.TESTSET = params.getOrDefault('TESTSET', '_boot_')
           println "Using TESTSET: ${env.TESTSET}"
+        }
+      }
+    }
+    stage('Verify provenance') {
+      steps {
+        script {
+          if(!params.containsKey('PROVENANCE_URL')) {
+            println "Missing PROVENANCE_URL parameter"
+            sh "exit 1"
+          }
+          sh "rm -fr ${TMP_PROVENANCE_DIR}"
+          // Wget occasionally fails due to a failure in name lookup. Below is a
+          // hack to force re-try a few times before aborting. Wget options, such
+          // as --tries, --waitretry, --retry-connrefused, etc. do not help in case
+          // the failure is due to an issue in name resolution which is considered
+          // a fatal error. Therefore, we need to add the below retry loop.
+          // TODO: remove the below re-try loop when test network DNS works
+          // reliably.
+          sh """
+            retry=1
+            max_retry=3
+            while ! wget -nv --show-progress --progress=dot:giga -P ${TMP_PROVENANCE_DIR} ${params.PROVENANCE_URL};
+            do
+              if (( \$retry >= \$max_retry )); then
+                echo "wget failed after \$retry retries"
+                exit 1
+              fi
+              retry=\$(( \$retry + 1 ))
+              sleep 5
+            done
+          """
+          sh "wget -nv -P ${TMP_PROVENANCE_DIR} ${params.PROVENANCE_URL}.sig"
+          sh "policy-checker ${TMP_PROVENANCE_DIR}/provenance.json --sig ${TMP_PROVENANCE_DIR}/provenance.json.sig --policy ${TRUST_POLICY_PATH}"
         }
       }
     }

--- a/utils.groovy
+++ b/utils.groovy
@@ -217,6 +217,7 @@ def ghaf_hw_test(String flakeref, String device_config, String testset='_boot_')
   def imgdir = find_img_relpath(flakeref, 'archive')
   def remote_path = "artifacts/${env.ARTIFACTS_REMOTE_PATH}"
   def img_url = "${env.JENKINS_URL}/${remote_path}/${imgdir}"
+  def provenance_url = "${env.JENKINS_URL}/${remote_path}/${flakeref_trim(flakeref)}/scs/provenance.json"
   def commit_hash = "${env.TARGET_COMMIT}"
   def build_url = "${env.JENKINS_URL}/job/${env.JOB_NAME}/${env.BUILD_ID}"
   def build_href = "<a href=\"${build_url}\">${env.JOB_NAME}#${env.BUILD_ID}</a>"
@@ -231,6 +232,7 @@ def ghaf_hw_test(String flakeref, String device_config, String testset='_boot_')
       string(name: "LABEL", value: "$device_config"),
       string(name: "DEVICE_CONFIG_NAME", value: "$device_config"),
       string(name: "IMG_URL", value: "$img_url"),
+      string(name: "PROVENANCE_URL", value: "$provenance_url"),
       string(name: "DESC", value: "$description"),
       string(name: "TESTSET", value: "$testset"),
       string(name: "TARGET", value: "$flakeref_trimmed"),


### PR DESCRIPTION
Adds a new stage to ghaf-hw-test which downloads the provenance file and its signature, then runs the policy checker on them. If the checks fail then then the image is not downloaded and tests are not run.

Depends on https://github.com/tiiuae/ghaf-infra/pull/465