### PR TITLE
Remove Lenovo-X1 Cosmic from nightly pipeline

### DIFF
--- a/ghaf-nightly-pipeline.groovy
+++ b/ghaf-nightly-pipeline.groovy
@@ -58,12 +58,6 @@ def targets = [
     scs: true,
     hwtest_device: null,
   ],
-  [ target: "lenovo-x1-gen11-cosmic-debug",
-    system: "x86_64-linux",
-    archive: true,
-    scs: false,
-    hwtest_device: "lenovo-x1",
-  ],
 
   // Dell Latitude rugged laptops
   [ target: "dell-latitude-7230-debug",


### PR DESCRIPTION
The standard `lenovo-x1-carbon-gen11-debug` image now uses Cosmic. The separate Cosmic target has been removed (https://github.com/tiiuae/ghaf/pull/1217).