### PR TITLE
Use provenance policy checker in ghaf-hw-test

### DIFF
--- a/ghaf-hw-test.groovy
+++ b/ghaf-hw-test.groovy
@@ -9,7 +9,9 @@ def REPO_URL = 'https://github.com/tiiuae/ci-test-automation/'
 def DEF_LABEL = 'testagent'
 def TMP_IMG_DIR = 'image'
 def TMP_SIG_DIR = 'signature'
+def TMP_PROVENANCE_DIR = 'provenance'
 def CONF_FILE_PATH = '/etc/jenkins/test_config.json'
+def TRUST_POLICY_PATH = '/etc/jenkins/provenance-trust-policy.json'
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -111,6 +113,36 @@ pipeline {
           }
           env.TESTSET = params.getOrDefault('TESTSET', '_boot_')
           println "Using TESTSET: ${env.TESTSET}"
+        }
+      }
+    }
+    stage('Verify provenance') {
+      when { expression { params.containsKey('PROVENANCE_URL') && params.PROVENANCE_URL != "null" } }
+      steps {
+        script {
+          sh "rm -fr ${TMP_PROVENANCE_DIR}"
+          // Wget occasionally fails due to a failure in name lookup. Below is a
+          // hack to force re-try a few times before aborting. Wget options, such
+          // as --tries, --waitretry, --retry-connrefused, etc. do not help in case
+          // the failure is due to an issue in name resolution which is considered
+          // a fatal error. Therefore, we need to add the below retry loop.
+          // TODO: remove the below re-try loop when test network DNS works
+          // reliably.
+          sh """
+            retry=1
+            max_retry=3
+            while ! wget -nv --show-progress --progress=dot:giga -P ${TMP_PROVENANCE_DIR} ${params.PROVENANCE_URL};
+            do
+              if (( \$retry >= \$max_retry )); then
+                echo "wget failed after \$retry retries"
+                exit 1
+              fi
+              retry=\$(( \$retry + 1 ))
+              sleep 5
+            done
+          """
+          sh "wget -nv -P ${TMP_PROVENANCE_DIR} ${params.PROVENANCE_URL}.sig"
+          sh "policy-checker ${TMP_PROVENANCE_DIR}/provenance.json --sig ${TMP_PROVENANCE_DIR}/provenance.json.sig --policy ${TRUST_POLICY_PATH}"
         }
       }
     }


### PR DESCRIPTION
Now the provenance verification is only attempted when it exists. If there is no provenance, the verification is skipped. This keeps pipelines that don't run scs working