### PR TITLE
Add System76 Darter Pro installers to Azure release pipelines

### DIFF
--- a/ghaf-release-laptop-pipeline.groovy
+++ b/ghaf-release-laptop-pipeline.groovy
@@ -56,6 +56,12 @@ def targets = [
     scs: true,
     hwtest_device: "darter-pro",
   ],
+    [ system: "x86_64-linux",
+    target: "system76-darp11-b-debug-installer",
+    archive: true,
+    scs: true,
+    hwtest_device: null,
+  ],
 ]
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ghaf-release-pipeline.groovy
+++ b/ghaf-release-pipeline.groovy
@@ -56,6 +56,12 @@ def targets = [
     scs: true,
     hwtest_device: "darter-pro",
   ],
+  [ system: "x86_64-linux",
+    target: "system76-darp11-b-debug-installer",
+    archive: true,
+    scs: true,
+    hwtest_device: null,
+  ],
 
   // nvidia orin
   [ system: "aarch64-linux",


### PR DESCRIPTION
Add Darter Pro installer to both release pipelines. No hardware tests, just like there are no hardware tests for X1 Carbon installer either.